### PR TITLE
fix: Failed_job_is_retried_and_eventually_succeeds flaky test

### DIFF
--- a/src/NexJob/Configuration.cs
+++ b/src/NexJob/Configuration.cs
@@ -47,6 +47,14 @@ public sealed class NexJobOptions
     /// Queues are drained in the order specified. Defaults to <c>["default"]</c>.
     /// </summary>
     public IReadOnlyList<string> Queues { get; set; } = ["default"];
+
+    /// <summary>
+    /// Computes the retry delay for a failed job given the attempt number (1-based).
+    /// Defaults to exponential backoff: <c>pow(attempt, 4) + 15 + rand(30) × (attempt + 1)</c> seconds.
+    /// Override in tests or when you need a different backoff strategy.
+    /// </summary>
+    public Func<int, TimeSpan> RetryDelayFactory { get; set; } = attempt =>
+        TimeSpan.FromSeconds(Math.Pow(attempt, 4) + 15 + Random.Shared.Next(30) * (attempt + 1));
 }
 
 /// <summary>

--- a/src/NexJob/Internal/JobDispatcherService.cs
+++ b/src/NexJob/Internal/JobDispatcherService.cs
@@ -163,10 +163,7 @@ internal sealed class JobDispatcherService : BackgroundService
 
             if (job.Attempts < job.MaxAttempts)
             {
-                var delaySec = Math.Pow(job.Attempts, 4)
-                               + 15
-                               + new Random().Next(30) * (job.Attempts + 1);
-                retryAt = DateTimeOffset.UtcNow.AddSeconds(delaySec);
+                retryAt = DateTimeOffset.UtcNow + _options.RetryDelayFactory(job.Attempts);
             }
             else
             {

--- a/tests/NexJob.IntegrationTests/EndToEnd/JobExecutionEndToEndTests.cs
+++ b/tests/NexJob.IntegrationTests/EndToEnd/JobExecutionEndToEndTests.cs
@@ -43,7 +43,7 @@ public sealed class JobExecutionEndToEndTests
     [Fact]
     public async Task Failed_job_is_retried_and_eventually_succeeds()
     {
-        var attempts = 0;
+        var counter   = new AttemptCounter();
         var succeeded = new TaskCompletionSource<bool>();
 
         using var host = Host.CreateDefaultBuilder()
@@ -51,11 +51,13 @@ public sealed class JobExecutionEndToEndTests
             {
                 services.AddNexJob(opt =>
                 {
-                    opt.Workers = 1;
-                    opt.PollingInterval = TimeSpan.FromMilliseconds(50);
-                    opt.MaxAttempts = 3;
+                    opt.Workers          = 1;
+                    opt.PollingInterval  = TimeSpan.FromMilliseconds(50);
+                    opt.MaxAttempts      = 3;
+                    // Use a short retry delay so the test completes in milliseconds
+                    opt.RetryDelayFactory = _ => TimeSpan.FromMilliseconds(100);
                 });
-                services.AddTransient(_ => new FlakyJob(ref attempts, succeeded));
+                services.AddTransient(_ => new FlakyJob(counter, succeeded));
             })
             .Build();
 
@@ -64,9 +66,9 @@ public sealed class JobExecutionEndToEndTests
         var scheduler = host.Services.GetRequiredService<IScheduler>();
         await scheduler.EnqueueAsync<FlakyJob, FlakyInput>(new());
 
-        var result = await succeeded.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        var result = await succeeded.Task.WaitAsync(TimeSpan.FromSeconds(10));
         result.Should().BeTrue();
-        attempts.Should().BeGreaterThan(1);
+        counter.Value.Should().BeGreaterThan(1);
 
         await host.StopAsync();
     }
@@ -118,14 +120,15 @@ public class SignalJob(TaskCompletionSource<string> signal) : IJob<SignalInput>
 
 public record FlakyInput;
 
-public class FlakyJob(ref int attempts, TaskCompletionSource<bool> done) : IJob<FlakyInput>
-{
-    private int _attempts = attempts;
+/// <summary>Shared mutable counter — survives across Transient DI instantiations.</summary>
+public sealed class AttemptCounter { public int Value; }
 
+public class FlakyJob(AttemptCounter counter, TaskCompletionSource<bool> done) : IJob<FlakyInput>
+{
     public Task ExecuteAsync(FlakyInput input, CancellationToken ct)
     {
-        _attempts++;
-        if (_attempts < 3) throw new InvalidOperationException("not yet");
+        counter.Value++;
+        if (counter.Value < 3) throw new InvalidOperationException("not yet");
         done.TrySetResult(true);
         return Task.CompletedTask;
     }


### PR DESCRIPTION
Two root causes:

1. FlakyJob used `ref int` in primary constructor which captures by value — each Transient DI instance started _attempts at 0 and never reached 3. Fixed by using a shared AttemptCounter (reference type) so all instances share the same counter.

2. The hardcoded exponential backoff (min 16 s on first retry) exceeded the 30 s test timeout. Added RetryDelayFactory to NexJobOptions — defaults to the same Hangfire-style formula, but the test overrides it to 100 ms so retries happen immediately.

## Summary

<!-- What does this PR do? One or two sentences. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New storage provider
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist

- [ ] `dotnet build` passes with **0 warnings**
- [ ] `dotnet test` passes — no regressions
- [ ] New behaviour is covered by tests
- [ ] Public API has XML documentation (`///`)
- [ ] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, etc.)

## Related issues

<!-- Closes #123 -->
