### PR TITLE
test: complete StorageProviderTestsBase contract coverage

### DIFF
--- a/tests/NexJob.IntegrationTests/StorageProviderTestsBase.cs
+++ b/tests/NexJob.IntegrationTests/StorageProviderTestsBase.cs
@@ -66,6 +66,30 @@ public abstract class StorageProviderTestsBase
         second.Should().BeNull();
     }
 
+    [Fact]
+    public async Task FetchNextAsync_returns_higher_priority_job_first()
+    {
+        var storage = await CreateStorageAsync();
+        await storage.EnqueueAsync(MakeJob(priority: JobPriority.Low));
+        await storage.EnqueueAsync(MakeJob(priority: JobPriority.Critical));
+        await storage.EnqueueAsync(MakeJob(priority: JobPriority.Normal));
+
+        var first = await storage.FetchNextAsync(["default"]);
+
+        first!.Priority.Should().Be(JobPriority.Critical);
+    }
+
+    [Fact]
+    public async Task FetchNextAsync_increments_attempts_on_claim()
+    {
+        var storage = await CreateStorageAsync();
+        await storage.EnqueueAsync(MakeJob());
+
+        var fetched = await storage.FetchNextAsync(["default"]);
+
+        fetched!.Attempts.Should().Be(1);
+    }
+
     // ── Status transitions ─────────────────────────────────────────────────────
 
     [Fact]
@@ -112,6 +136,22 @@ public abstract class StorageProviderTestsBase
         updated!.Status.Should().Be(JobStatus.Failed);
     }
 
+    [Fact]
+    public async Task UpdateHeartbeatAsync_updates_heartbeat_timestamp()
+    {
+        var storage = await CreateStorageAsync();
+        await storage.EnqueueAsync(MakeJob());
+        var fetched = (await storage.FetchNextAsync(["default"]))!;
+        var before  = fetched.HeartbeatAt;
+
+        await Task.Delay(10); // ensure clock advances
+        await storage.UpdateHeartbeatAsync(fetched.Id);
+        var updated = await storage.GetJobByIdAsync(fetched.Id);
+
+        updated!.HeartbeatAt.Should().NotBeNull();
+        updated.HeartbeatAt.Should().BeAfter(before ?? DateTimeOffset.MinValue);
+    }
+
     // ── Idempotency ────────────────────────────────────────────────────────────
 
     [Fact]
@@ -120,11 +160,77 @@ public abstract class StorageProviderTestsBase
         var storage = await CreateStorageAsync();
         var key     = Guid.NewGuid().ToString();
 
-        await storage.EnqueueAsync(MakeJob(idempotencyKey: key));
-        await storage.EnqueueAsync(MakeJob(idempotencyKey: key));
+        var id1 = await storage.EnqueueAsync(MakeJob(idempotencyKey: key));
+        var id2 = await storage.EnqueueAsync(MakeJob(idempotencyKey: key));
 
+        id1.Should().Be(id2, "second enqueue with same key must return the existing job id");
         var metrics = await storage.GetMetricsAsync();
         metrics.Enqueued.Should().Be(1);
+    }
+
+    // ── Orphan requeue ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RequeueOrphanedJobsAsync_requeues_stale_processing_job()
+    {
+        var storage = await CreateStorageAsync();
+        await storage.EnqueueAsync(MakeJob());
+        var fetched = (await storage.FetchNextAsync(["default"]))!;
+        fetched.Status.Should().Be(JobStatus.Processing);
+
+        // heartbeat_at was just set; pass zero timeout so the cutoff = UtcNow,
+        // which is after the heartbeat that was set a few ms ago
+        await Task.Delay(10);
+        await storage.RequeueOrphanedJobsAsync(TimeSpan.Zero);
+
+        var updated = await storage.GetJobByIdAsync(fetched.Id);
+        updated!.Status.Should().Be(JobStatus.Enqueued);
+        updated.HeartbeatAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RequeueOrphanedJobsAsync_does_not_touch_fresh_heartbeat()
+    {
+        var storage = await CreateStorageAsync();
+        await storage.EnqueueAsync(MakeJob());
+        var fetched = (await storage.FetchNextAsync(["default"]))!;
+
+        // Large timeout — the job heartbeat is fresh, should not be requeued
+        await storage.RequeueOrphanedJobsAsync(TimeSpan.FromMinutes(5));
+
+        var updated = await storage.GetJobByIdAsync(fetched.Id);
+        updated!.Status.Should().Be(JobStatus.Processing);
+    }
+
+    // ── Continuations ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EnqueueContinuationsAsync_releases_awaiting_jobs()
+    {
+        var storage  = await CreateStorageAsync();
+        var parentId = new JobId(Guid.NewGuid());
+        var child    = MakeJob(status: JobStatus.AwaitingContinuation, parentJobId: parentId);
+        await storage.EnqueueAsync(child);
+
+        await storage.EnqueueContinuationsAsync(parentId);
+
+        var updated = await storage.GetJobByIdAsync(child.Id);
+        updated!.Status.Should().Be(JobStatus.Enqueued);
+    }
+
+    [Fact]
+    public async Task EnqueueContinuationsAsync_does_not_release_other_parents_jobs()
+    {
+        var storage  = await CreateStorageAsync();
+        var parentA  = new JobId(Guid.NewGuid());
+        var parentB  = new JobId(Guid.NewGuid());
+        var childOfB = MakeJob(status: JobStatus.AwaitingContinuation, parentJobId: parentB);
+        await storage.EnqueueAsync(childOfB);
+
+        await storage.EnqueueContinuationsAsync(parentA);
+
+        var updated = await storage.GetJobByIdAsync(childOfB.Id);
+        updated!.Status.Should().Be(JobStatus.AwaitingContinuation, "only parentB's children should be released");
     }
 
     // ── Dashboard methods ──────────────────────────────────────────────────────
@@ -142,6 +248,40 @@ public abstract class StorageProviderTestsBase
     }
 
     [Fact]
+    public async Task GetMetricsAsync_counts_all_statuses()
+    {
+        var storage = await CreateStorageAsync();
+
+        // → Processing: fetch job A, leave it running
+        await storage.EnqueueAsync(MakeJob());
+        var processing = (await storage.FetchNextAsync(["default"]))!;
+
+        // → Succeeded: fetch job B, acknowledge it
+        await storage.EnqueueAsync(MakeJob());
+        var toSucceed = (await storage.FetchNextAsync(["default"]))!;
+        await storage.AcknowledgeAsync(toSucceed.Id);
+
+        // → Failed: fetch job C, fail it with no retry
+        await storage.EnqueueAsync(MakeJob());
+        var toFail = (await storage.FetchNextAsync(["default"]))!;
+        await storage.SetFailedAsync(toFail.Id, new Exception("x"), retryAt: null);
+
+        // → Enqueued: job D — just enqueued, not fetched
+        await storage.EnqueueAsync(MakeJob());
+
+        // → Recurring
+        await storage.UpsertRecurringJobAsync(MakeRecurring());
+
+        var metrics = await storage.GetMetricsAsync();
+
+        metrics.Enqueued.Should().Be(1);
+        metrics.Processing.Should().Be(1);
+        metrics.Succeeded.Should().Be(1);
+        metrics.Failed.Should().Be(1);
+        metrics.Recurring.Should().Be(1);
+    }
+
+    [Fact]
     public async Task GetJobsAsync_returns_paged_results()
     {
         var storage = await CreateStorageAsync();
@@ -153,6 +293,37 @@ public abstract class StorageProviderTestsBase
         page.Items.Should().HaveCount(3);
         page.TotalCount.Should().Be(5);
         page.TotalPages.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetJobsAsync_filters_by_status()
+    {
+        var storage = await CreateStorageAsync();
+        await storage.EnqueueAsync(MakeJob());
+        var fetched = (await storage.FetchNextAsync(["default"]))!;
+        await storage.AcknowledgeAsync(fetched.Id);
+        await storage.EnqueueAsync(MakeJob()); // still Enqueued
+
+        var page = await storage.GetJobsAsync(
+            new JobFilter { Status = JobStatus.Succeeded }, page: 1, pageSize: 10);
+
+        page.Items.Should().HaveCount(1);
+        page.Items[0].Status.Should().Be(JobStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task GetJobsAsync_filters_by_queue()
+    {
+        var storage = await CreateStorageAsync();
+        await storage.EnqueueAsync(MakeJob(queue: "alpha"));
+        await storage.EnqueueAsync(MakeJob(queue: "alpha"));
+        await storage.EnqueueAsync(MakeJob(queue: "beta"));
+
+        var page = await storage.GetJobsAsync(
+            new JobFilter { Queue = "alpha" }, page: 1, pageSize: 10);
+
+        page.TotalCount.Should().Be(2);
+        page.Items.Should().AllSatisfy(j => j.Queue.Should().Be("alpha"));
     }
 
     [Fact]
@@ -194,56 +365,148 @@ public abstract class StorageProviderTestsBase
         updated.Attempts.Should().Be(0);
     }
 
+    [Fact]
+    public async Task GetQueueMetricsAsync_returns_counts_per_queue()
+    {
+        var storage = await CreateStorageAsync();
+        await storage.EnqueueAsync(MakeJob(queue: "alpha"));
+        await storage.EnqueueAsync(MakeJob(queue: "alpha"));
+        await storage.EnqueueAsync(MakeJob(queue: "beta"));
+        // Claim one from alpha → Processing
+        await storage.FetchNextAsync(["alpha"]);
+
+        var metrics = await storage.GetQueueMetricsAsync();
+
+        var alpha = metrics.First(q => q.Queue == "alpha");
+        var beta  = metrics.First(q => q.Queue == "beta");
+
+        alpha.Enqueued.Should().Be(1);
+        alpha.Processing.Should().Be(1);
+        beta.Enqueued.Should().Be(1);
+        beta.Processing.Should().Be(0);
+    }
+
     // ── Recurring jobs ─────────────────────────────────────────────────────────
 
     [Fact]
     public async Task UpsertRecurringJobAsync_and_GetRecurringJobsAsync_roundtrip()
     {
         var storage   = await CreateStorageAsync();
-        var recurring = new RecurringJobRecord
-        {
-            RecurringJobId = $"test-job-{Guid.NewGuid()}",
-            JobType        = "MyJob",
-            InputType      = "MyInput",
-            InputJson      = "{}",
-            Cron           = "* * * * *",
-            Queue          = "default",
-            NextExecution  = DateTimeOffset.UtcNow,
-        };
+        var recurring = MakeRecurring();
 
         await storage.UpsertRecurringJobAsync(recurring);
         var all = await storage.GetRecurringJobsAsync();
 
-        all.Should().Contain(r => r.RecurringJobId == recurring.RecurringJobId);
+        var saved = all.Should().ContainSingle(r => r.RecurringJobId == recurring.RecurringJobId).Subject;
+        saved.Cron.Should().Be(recurring.Cron);
+        saved.Queue.Should().Be(recurring.Queue);
+        saved.ConcurrencyPolicy.Should().Be(recurring.ConcurrencyPolicy);
+    }
+
+    [Fact]
+    public async Task UpsertRecurringJobAsync_updates_existing_definition()
+    {
+        var storage = await CreateStorageAsync();
+        var id      = $"upsert-test-{Guid.NewGuid()}";
+        await storage.UpsertRecurringJobAsync(MakeRecurring(id: id, cron: "* * * * *"));
+
+        await storage.UpsertRecurringJobAsync(MakeRecurring(id: id, cron: "0 9 * * *"));
+        var all = await storage.GetRecurringJobsAsync();
+
+        all.Should().ContainSingle(r => r.RecurringJobId == id)
+           .Which.Cron.Should().Be("0 9 * * *");
+    }
+
+    [Fact]
+    public async Task GetDueRecurringJobsAsync_returns_only_due_jobs()
+    {
+        var storage = await CreateStorageAsync();
+        var dueId    = $"due-{Guid.NewGuid()}";
+        var futureId = $"future-{Guid.NewGuid()}";
+
+        await storage.UpsertRecurringJobAsync(
+            MakeRecurring(id: dueId,    nextExecution: DateTimeOffset.UtcNow.AddSeconds(-1)));
+        await storage.UpsertRecurringJobAsync(
+            MakeRecurring(id: futureId, nextExecution: DateTimeOffset.UtcNow.AddHours(1)));
+
+        var due = await storage.GetDueRecurringJobsAsync(DateTimeOffset.UtcNow);
+
+        due.Should().Contain(r => r.RecurringJobId == dueId);
+        due.Should().NotContain(r => r.RecurringJobId == futureId);
+    }
+
+    [Fact]
+    public async Task SetRecurringJobNextExecutionAsync_persists_next_and_last_execution()
+    {
+        var storage   = await CreateStorageAsync();
+        var recurring = MakeRecurring();
+        await storage.UpsertRecurringJobAsync(recurring);
+
+        var next = DateTimeOffset.UtcNow.AddMinutes(5);
+        await storage.SetRecurringJobNextExecutionAsync(recurring.RecurringJobId, next);
+
+        var all   = await storage.GetRecurringJobsAsync();
+        var saved = all.Single(r => r.RecurringJobId == recurring.RecurringJobId);
+
+        saved.NextExecution.Should().NotBeNull();
+        saved.LastExecutedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task SetRecurringJobLastExecutionResultAsync_records_success()
+    {
+        var storage   = await CreateStorageAsync();
+        var recurring = MakeRecurring();
+        await storage.UpsertRecurringJobAsync(recurring);
+
+        await storage.SetRecurringJobLastExecutionResultAsync(
+            recurring.RecurringJobId, JobStatus.Succeeded, errorMessage: null);
+
+        var all   = await storage.GetRecurringJobsAsync();
+        var saved = all.Single(r => r.RecurringJobId == recurring.RecurringJobId);
+
+        saved.LastExecutionStatus.Should().Be(JobStatus.Succeeded);
+        saved.LastExecutionError.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SetRecurringJobLastExecutionResultAsync_records_failure_with_error()
+    {
+        var storage   = await CreateStorageAsync();
+        var recurring = MakeRecurring();
+        await storage.UpsertRecurringJobAsync(recurring);
+
+        await storage.SetRecurringJobLastExecutionResultAsync(
+            recurring.RecurringJobId, JobStatus.Failed, errorMessage: "timeout");
+
+        var all   = await storage.GetRecurringJobsAsync();
+        var saved = all.Single(r => r.RecurringJobId == recurring.RecurringJobId);
+
+        saved.LastExecutionStatus.Should().Be(JobStatus.Failed);
+        saved.LastExecutionError.Should().Be("timeout");
     }
 
     [Fact]
     public async Task DeleteRecurringJobAsync_removes_the_definition()
     {
         var storage   = await CreateStorageAsync();
-        var id        = $"to-delete-{Guid.NewGuid()}";
-        var recurring = new RecurringJobRecord
-        {
-            RecurringJobId = id,
-            JobType        = "MyJob",
-            InputType      = "MyInput",
-            InputJson      = "{}",
-            Cron           = "* * * * *",
-            Queue          = "default",
-        };
+        var recurring = MakeRecurring();
         await storage.UpsertRecurringJobAsync(recurring);
 
-        await storage.DeleteRecurringJobAsync(id);
+        await storage.DeleteRecurringJobAsync(recurring.RecurringJobId);
         var all = await storage.GetRecurringJobsAsync();
 
-        all.Should().NotContain(r => r.RecurringJobId == id);
+        all.Should().NotContain(r => r.RecurringJobId == recurring.RecurringJobId);
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────
 
     private static JobRecord MakeJob(
         string queue           = "default",
-        string? idempotencyKey = null) =>
+        string? idempotencyKey = null,
+        JobPriority priority   = JobPriority.Normal,
+        JobStatus status       = JobStatus.Enqueued,
+        JobId? parentJobId     = null) =>
         new()
         {
             Id             = new JobId(Guid.NewGuid()),
@@ -251,10 +514,28 @@ public abstract class StorageProviderTestsBase
             InputType      = "NexJob.IntegrationTests.FakeInput",
             InputJson      = $"{{\"seq\":\"{Guid.NewGuid()}\"}}",
             Queue          = queue,
-            Priority       = JobPriority.Normal,
-            Status         = JobStatus.Enqueued,
+            Priority       = priority,
+            Status         = status,
             MaxAttempts    = 5,
             CreatedAt      = DateTimeOffset.UtcNow,
             IdempotencyKey = idempotencyKey,
+            ParentJobId    = parentJobId,
+        };
+
+    private static RecurringJobRecord MakeRecurring(
+        string? id             = null,
+        string cron            = "* * * * *",
+        DateTimeOffset? nextExecution = null) =>
+        new()
+        {
+            RecurringJobId    = id ?? $"test-recurring-{Guid.NewGuid()}",
+            JobType           = "NexJob.IntegrationTests.FakeJob",
+            InputType         = "NexJob.IntegrationTests.FakeInput",
+            InputJson         = "{}",
+            Cron              = cron,
+            Queue             = "default",
+            NextExecution     = nextExecution ?? DateTimeOffset.UtcNow,
+            CreatedAt         = DateTimeOffset.UtcNow,
+            ConcurrencyPolicy = RecurringConcurrencyPolicy.SkipIfRunning,
         };
 }


### PR DESCRIPTION
## Summary

- Adds 15 new contract tests covering every `IStorageProvider` method that was previously untested or only weakly tested
- Strengthened existing idempotency test to also assert the returned `JobId` matches the original
- All 31 InMemory tests pass locally; Postgres + MongoDB are exercised in CI via Testcontainers

## New tests

| Test | Method covered |
|------|---------------|
| `FetchNextAsync_returns_higher_priority_job_first` | `FetchNextAsync` priority ordering |
| `FetchNextAsync_increments_attempts_on_claim` | `FetchNextAsync` attempt counter |
| `UpdateHeartbeatAsync_updates_heartbeat_timestamp` | `UpdateHeartbeatAsync` |
| `EnqueueAsync_with_same_idempotency_key_is_deduplicated` | idempotency + returned `JobId` |
| `RequeueOrphanedJobsAsync_requeues_stale_processing_job` | `RequeueOrphanedJobsAsync` |
| `RequeueOrphanedJobsAsync_does_not_touch_fresh_heartbeat` | `RequeueOrphanedJobsAsync` |
| `EnqueueContinuationsAsync_releases_awaiting_jobs` | `EnqueueContinuationsAsync` |
| `EnqueueContinuationsAsync_does_not_release_other_parents_jobs` | `EnqueueContinuationsAsync` isolation |
| `GetMetricsAsync_counts_all_statuses` | `GetMetricsAsync` all status buckets |
| `GetJobsAsync_filters_by_status` | `GetJobsAsync` status filter |
| `GetJobsAsync_filters_by_queue` | `GetJobsAsync` queue filter |
| `GetQueueMetricsAsync_returns_counts_per_queue` | `GetQueueMetricsAsync` |
| `UpsertRecurringJobAsync_updates_existing_definition` | upsert semantics |
| `GetDueRecurringJobsAsync_returns_only_due_jobs` | `GetDueRecurringJobsAsync` |
| `SetRecurringJobNextExecutionAsync_persists_next_and_last_execution` | `SetRecurringJobNextExecutionAsync` |
| `SetRecurringJobLastExecutionResultAsync_records_success` | `SetRecurringJobLastExecutionResultAsync` |
| `SetRecurringJobLastExecutionResultAsync_records_failure_with_error` | failure with error message |

## Test plan

- [x] `dotnet test tests/NexJob.Tests/` — 48 unit tests pass
- [x] `dotnet test tests/NexJob.IntegrationTests/ --filter InMemory` — 31 contract tests pass
- [x] `dotnet test tests/NexJob.IntegrationTests/ --filter EndToEnd` — 3 end-to-end tests pass
- [ ] CI runs Postgres + MongoDB via Testcontainers (Docker required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)