### PR TITLE
feat: real-time SSE metrics on dashboard overview

### DIFF
--- a/src/NexJob.Dashboard/DashboardMiddleware.cs
+++ b/src/NexJob.Dashboard/DashboardMiddleware.cs
@@ -46,6 +46,14 @@ public sealed class DashboardMiddleware
 
         var subPath = path[_pathPrefix.Length..].TrimStart('/');
 
+        // SSE metrics stream
+        if (subPath == "stream" && context.Request.Method == HttpMethods.Get)
+        {
+            var storage = context.RequestServices.GetRequiredService<IStorageProvider>();
+            await DashboardStreamEndpoint.HandleAsync(context, storage);
+            return;
+        }
+
         // Handle API actions (POST)
         if (context.Request.Method == HttpMethods.Post && await HandleActionsAsync(context, subPath))
             return;

--- a/src/NexJob.Dashboard/DashboardStreamEndpoint.cs
+++ b/src/NexJob.Dashboard/DashboardStreamEndpoint.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using NexJob.Storage;
+
+namespace NexJob.Dashboard;
+
+/// <summary>
+/// Handles the <c>GET {prefix}/stream</c> endpoint that pushes metric snapshots to the browser
+/// using Server-Sent Events (SSE). The connection stays open until the client disconnects or
+/// the host shuts down.
+/// </summary>
+internal static class DashboardStreamEndpoint
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(3);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    /// <summary>
+    /// Streams <see cref="JobMetrics"/> snapshots as SSE events until the request is aborted.
+    /// Each event carries a compact JSON object with the six numeric counters.
+    /// </summary>
+    internal static async Task HandleAsync(HttpContext context, IStorageProvider storage)
+    {
+        context.Response.ContentType  = "text/event-stream";
+        context.Response.Headers["Cache-Control"]      = "no-cache";
+        context.Response.Headers["X-Accel-Buffering"]  = "no"; // disable nginx proxy buffering
+
+        var ct = context.RequestAborted;
+
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var metrics = await storage.GetMetricsAsync(ct);
+
+                var payload = JsonSerializer.Serialize(new
+                {
+                    metrics.Enqueued,
+                    metrics.Processing,
+                    metrics.Succeeded,
+                    metrics.Failed,
+                    metrics.Scheduled,
+                    metrics.Recurring,
+                }, JsonOptions);
+
+                await context.Response.WriteAsync($"data: {payload}\n\n", ct);
+                await context.Response.Body.FlushAsync(ct);
+
+                await Task.Delay(PollInterval, ct);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Client disconnected or host shutting down — normal exit
+        }
+    }
+}

--- a/src/NexJob.Dashboard/Pages/OverviewPage.cs
+++ b/src/NexJob.Dashboard/Pages/OverviewPage.cs
@@ -40,12 +40,12 @@ internal sealed class OverviewPage : IComponent
         var body =
             $"<h1 class=\"page-title\">Overview</h1>" +
             $"<div class=\"cards\">" +
-            $"<div class=\"card\"><div class=\"card-label\">Enqueued</div><div class=\"card-value enqueued\">{m.Enqueued}</div></div>" +
-            $"<div class=\"card\"><div class=\"card-label\">Processing</div><div class=\"card-value processing\">{m.Processing}</div></div>" +
-            $"<div class=\"card\"><div class=\"card-label\">Succeeded</div><div class=\"card-value succeeded\">{m.Succeeded}</div></div>" +
-            $"<div class=\"card\"><div class=\"card-label\">Failed</div><div class=\"card-value failed\">{m.Failed}</div></div>" +
-            $"<div class=\"card\"><div class=\"card-label\">Scheduled</div><div class=\"card-value scheduled\">{m.Scheduled}</div></div>" +
-            $"<div class=\"card\"><div class=\"card-label\">Recurring</div><div class=\"card-value recurring\">{m.Recurring}</div></div>" +
+            $"<div class=\"card\"><div class=\"card-label\">Enqueued</div><div id=\"metric-enqueued\" class=\"card-value enqueued\">{m.Enqueued}</div></div>" +
+            $"<div class=\"card\"><div class=\"card-label\">Processing</div><div id=\"metric-processing\" class=\"card-value processing\">{m.Processing}</div></div>" +
+            $"<div class=\"card\"><div class=\"card-label\">Succeeded</div><div id=\"metric-succeeded\" class=\"card-value succeeded\">{m.Succeeded}</div></div>" +
+            $"<div class=\"card\"><div class=\"card-label\">Failed</div><div id=\"metric-failed\" class=\"card-value failed\">{m.Failed}</div></div>" +
+            $"<div class=\"card\"><div class=\"card-label\">Scheduled</div><div id=\"metric-scheduled\" class=\"card-value scheduled\">{m.Scheduled}</div></div>" +
+            $"<div class=\"card\"><div class=\"card-label\">Recurring</div><div id=\"metric-recurring\" class=\"card-value recurring\">{m.Recurring}</div></div>" +
             $"</div>" +
             $"<div class=\"chart\"><h2>Throughput — last 24h</h2>" +
             (bars.Length > 0 ? $"<div class=\"bars\">{bars}</div>" : "<p style=\"color:var(--text-muted)\">No completed jobs in the last 24 hours.</p>") +
@@ -54,7 +54,20 @@ internal sealed class OverviewPage : IComponent
             (m.RecentFailures.Count == 0
                 ? "<p style=\"color:var(--text-muted)\">No failures. 🎉</p>"
                 : $"<table><thead><tr><th>ID</th><th>Type</th><th>Queue</th><th>Failed At</th><th>Error</th></tr></thead><tbody>{failRows}</tbody></table>") +
-            "</div>";
+            "</div>" +
+            $"<script>(function(){{" +
+            $"var es=new EventSource('{PathPrefix}/stream');" +
+            $"es.onmessage=function(e){{" +
+            $"var m=JSON.parse(e.data);" +
+            $"document.getElementById('metric-enqueued').textContent=m.enqueued;" +
+            $"document.getElementById('metric-processing').textContent=m.processing;" +
+            $"document.getElementById('metric-succeeded').textContent=m.succeeded;" +
+            $"document.getElementById('metric-failed').textContent=m.failed;" +
+            $"document.getElementById('metric-scheduled').textContent=m.scheduled;" +
+            $"document.getElementById('metric-recurring').textContent=m.recurring;" +
+            $"}};" +
+            $"es.onerror=function(){{es.close();}};" +
+            $"}})();</script>";
 
         return HtmlShell.Wrap(Title, PathPrefix, "overview", body);
     }


### PR DESCRIPTION
## Summary

- New `GET {prefix}/stream` endpoint streams `JobMetrics` to the browser every 3 seconds via Server-Sent Events — no page reload needed
- Overview metric cards (Enqueued, Processing, Succeeded, Failed, Scheduled, Recurring) update live
- ~10 lines of vanilla JS injected inline; zero new npm dependencies, zero new NuGet dependencies

## How it works

```
Browser                        ASP.NET Core
  |  GET /jobs/stream              |
  |------------------------------> |
  |                                | (connection stays open)
  | <-- data: {"enqueued":5,...}   |  every 3 s
  | <-- data: {"enqueued":4,...}   |
```

**New file:** `DashboardStreamEndpoint.cs` — static handler, loops on `GetMetricsAsync` + `Task.Delay(3s)`, exits cleanly on `RequestAborted`.

**Middleware change:** routes `GET .../stream` before the POST handler and page renderer.

**OverviewPage change:** adds `id="metric-*"` to each card value div + tiny `<script>` with `EventSource`.

## Test plan

- [x] `dotnet build` — 0 warnings
- [x] 48 unit tests pass
- [x] 34 InMemory + E2E integration tests pass
- [ ] CI Postgres + MongoDB via Testcontainers

🤖 Generated with [Claude Code](https://claude.com/claude-code)