### PR TITLE
chore: enforce SA1413 trailing commas — remove suppression

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -136,11 +136,6 @@ dotnet_diagnostic.SA1001.severity = none
 # Related to SA1116/SA1117; same reason for suppression.
 dotnet_diagnostic.SA1114.severity = none
 
-# SA1413 — use trailing comma in multi-line initializers.
-# Good practice going forward, but retroactively fixing all existing initializers
-# is too much churn. New code should use trailing commas; existing code is left as-is.
-dotnet_diagnostic.SA1413.severity = none
-
 # ── Test project overrides ────────────────────────────────────────────────────
 # Tests have different style requirements: readability > formality.
 # StyleCop rules are suppressed; Sonar rules that catch real bugs remain active.
@@ -153,7 +148,6 @@ dotnet_diagnostic.SA1204.severity = none
 dotnet_diagnostic.SA1210.severity = none
 dotnet_diagnostic.SA1309.severity = none
 dotnet_diagnostic.SA1402.severity = none
-dotnet_diagnostic.SA1413.severity = none
 dotnet_diagnostic.SA1503.severity = none
 dotnet_diagnostic.SA1512.severity = none
 dotnet_diagnostic.SA1515.severity = none


### PR DESCRIPTION
## Summary

- Removes the `SA1413` suppression from `.editorconfig` (both global and `[tests/**/*.cs]` sections)
- SA1413 requires trailing commas on all multi-line object/collection initializers
- No code changes needed: all initializers were already compliant from the previous analyzer pass
- Result: 0 errors, 0 warnings, 48/48 tests passing

## Why

Trailing commas make diffs cleaner (adding a new member doesn't touch the previous line), reduce merge conflicts, and are the modern C# convention.

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test tests/NexJob.Tests/` — 48/48 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)