### PR TITLE
feat: configure NuGet packaging and publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+name: Publish to NuGet
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - run: dotnet restore
+      - run: dotnet build --no-restore --configuration Release
+      - run: dotnet test tests/NexJob.Tests --no-build --configuration Release
+
+  publish:
+    name: Pack & Publish
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+      - name: Restore & Build
+        run: |
+          dotnet restore
+          dotnet build --no-restore --configuration Release
+      - name: Pack
+        run: |
+          dotnet pack src/NexJob/NexJob.csproj \
+            --no-build --configuration Release \
+            -p:VersionPrefix=${{ steps.version.outputs.VERSION }} \
+            -p:VersionSuffix= \
+            --output ./nupkg
+          dotnet pack src/NexJob.Postgres/NexJob.Postgres.csproj \
+            --no-build --configuration Release \
+            -p:VersionPrefix=${{ steps.version.outputs.VERSION }} \
+            -p:VersionSuffix= \
+            --output ./nupkg
+          dotnet pack src/NexJob.MongoDB/NexJob.MongoDB.csproj \
+            --no-build --configuration Release \
+            -p:VersionPrefix=${{ steps.version.outputs.VERSION }} \
+            -p:VersionSuffix= \
+            --output ./nupkg
+          dotnet pack src/NexJob.Dashboard/NexJob.Dashboard.csproj \
+            --no-build --configuration Release \
+            -p:VersionPrefix=${{ steps.version.outputs.VERSION }} \
+            -p:VersionSuffix= \
+            --output ./nupkg
+      - name: Push to NuGet.org
+        run: |
+          dotnet nuget push ./nupkg/*.nupkg \
+            --api-key ${{ secrets.NUGET_API_KEY }} \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <VersionPrefix>0.1.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
+    <PackageProjectUrl>https://github.com/oluciano/NexJob</PackageProjectUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <!-- Analyzers applied to every project in the solution -->

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+# NexJob — packaging helpers
+# Usage:
+#   make pack                   → pack all projects (version from Directory.Build.props)
+#   make pack VERSION=0.1.0     → pack with explicit version
+#   make publish                → push ./nupkg/*.nupkg to NuGet.org (requires NUGET_API_KEY env var)
+#   make clean-pack             → delete ./nupkg output directory
+
+VERSION_PREFIX ?=
+VERSION_SUFFIX ?=
+
+PACK_ARGS = --configuration Release --output ./nupkg
+ifdef VERSION_PREFIX
+  PACK_ARGS += -p:VersionPrefix=$(VERSION_PREFIX) -p:VersionSuffix=
+endif
+
+PROJECTS = \
+  src/NexJob/NexJob.csproj \
+  src/NexJob.Postgres/NexJob.Postgres.csproj \
+  src/NexJob.MongoDB/NexJob.MongoDB.csproj \
+  src/NexJob.Dashboard/NexJob.Dashboard.csproj
+
+.PHONY: pack publish clean-pack
+
+pack:
+	dotnet build --configuration Release
+	$(foreach proj,$(PROJECTS),dotnet pack $(proj) --no-build $(PACK_ARGS);)
+
+publish:
+	@test -n "$(NUGET_API_KEY)" || (echo "Error: NUGET_API_KEY is not set" && exit 1)
+	dotnet nuget push "./nupkg/*.nupkg" \
+		--api-key $(NUGET_API_KEY) \
+		--source https://api.nuget.org/v3/index.json \
+		--skip-duplicate
+
+clean-pack:
+	rm -rf ./nupkg

--- a/src/NexJob.Dashboard/NexJob.Dashboard.csproj
+++ b/src/NexJob.Dashboard/NexJob.Dashboard.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <PackageId>NexJob.Dashboard</PackageId>
-    <Description>Blazor SSR dashboard middleware for NexJob.</Description>
+    <IsPackable>true</IsPackable>
+    <PackageTags>background-jobs;scheduler;dashboard;blazor;aspnetcore;dotnet</PackageTags>
+    <Description>Blazor SSR dashboard middleware for NexJob — real-time monitoring of background jobs.</Description>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/src/NexJob.MongoDB/NexJob.MongoDB.csproj
+++ b/src/NexJob.MongoDB/NexJob.MongoDB.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <PackageId>NexJob.MongoDB</PackageId>
-    <Description>MongoDB storage provider for NexJob.</Description>
+    <IsPackable>true</IsPackable>
+    <PackageTags>background-jobs;scheduler;mongodb;nosql;dotnet</PackageTags>
+    <Description>MongoDB storage provider for NexJob — the open-source background job scheduler for .NET 8+.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NexJob.Oracle/NexJob.Oracle.csproj
+++ b/src/NexJob.Oracle/NexJob.Oracle.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <PackageId>NexJob.Oracle</PackageId>
+    <IsPackable>false</IsPackable>
     <Description>Oracle storage provider for NexJob.</Description>
   </PropertyGroup>
 

--- a/src/NexJob.Postgres/NexJob.Postgres.csproj
+++ b/src/NexJob.Postgres/NexJob.Postgres.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <PackageId>NexJob.Postgres</PackageId>
-    <Description>PostgreSQL storage provider for NexJob.</Description>
+    <IsPackable>true</IsPackable>
+    <PackageTags>background-jobs;scheduler;postgresql;postgres;npgsql;dapper;dotnet</PackageTags>
+    <Description>PostgreSQL storage provider for NexJob — the open-source background job scheduler for .NET 8+.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NexJob.Redis/NexJob.Redis.csproj
+++ b/src/NexJob.Redis/NexJob.Redis.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <PackageId>NexJob.Redis</PackageId>
+    <IsPackable>false</IsPackable>
     <Description>Redis storage provider for NexJob.</Description>
   </PropertyGroup>
 

--- a/src/NexJob.SqlServer/NexJob.SqlServer.csproj
+++ b/src/NexJob.SqlServer/NexJob.SqlServer.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <PackageId>NexJob.SqlServer</PackageId>
+    <IsPackable>false</IsPackable>
     <Description>SQL Server storage provider for NexJob.</Description>
   </PropertyGroup>
 

--- a/src/NexJob/NexJob.csproj
+++ b/src/NexJob/NexJob.csproj
@@ -2,8 +2,15 @@
 
   <PropertyGroup>
     <PackageId>NexJob</PackageId>
-    <Description>Modern background job scheduler for .NET 8+ — open-source Hangfire alternative with native async/await, priority queues, and resource throttling.</Description>
+    <IsPackable>true</IsPackable>
+    <PackageTags>background-jobs;scheduler;queue;hangfire;async;dotnet</PackageTags>
+    <Description>Modern background job scheduler for .NET 8+. Open-source Hangfire alternative with native async/await, priority queues, resource throttling, and pluggable storage.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\..\icon.png" Pack="true" PackagePath="\" Condition="Exists('..\..\icon.png')"/>
+  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">


### PR DESCRIPTION
## Summary

- Adds NuGet metadata to all publishable packages via `Directory.Build.props` and individual `.csproj` files
- Marks stub packages (SqlServer, Redis, Oracle) as `IsPackable=false` — not published until implemented
- Embeds `README.md` in the core `NexJob` package (shown on nuget.org)
- Creates `.github/workflows/publish.yml`: push a `v*` tag → tests run → all 4 packages packed and pushed to nuget.org
- Creates `Makefile` for local publishing

## How to publish

**Via GitHub Actions (recommended):**
```sh
git tag v0.1.0
git push origin v0.1.0
```
Requires `NUGET_API_KEY` secret in GitHub Settings → Secrets → Actions.

**Manually from command line:**
```sh
export NUGET_API_KEY=your_key_here
make pack VERSION=0.1.0
make publish
```

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)