### PR TITLE
fix: remove missing icon.png and update CI actions to Node.js 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,8 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-dotnet@v4.3.1
         with:
           dotnet-version: 8.0.x
       - run: dotnet restore
@@ -23,8 +23,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-dotnet@v4.3.1
         with:
           dotnet-version: 8.0.x
       - name: Extract version from tag

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,6 @@
     <VersionSuffix>alpha</VersionSuffix>
     <PackageProjectUrl>https://github.com/oluciano/NexJob</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/NexJob/NexJob.csproj
+++ b/src/NexJob/NexJob.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
-    <None Include="..\..\icon.png" Pack="true" PackagePath="\" Condition="Exists('..\..\icon.png')"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Removed `<PackageIcon>icon.png</PackageIcon>` from `Directory.Build.props` — file doesn't exist in repo, was causing `dotnet pack` to fail in CI with *"The icon file 'icon.png' does not exist in the package"*
- Removed conditional `icon.png` Include from `NexJob.csproj`
- Pinned `actions/checkout` to `v4.2.2` and `actions/setup-dotnet` to `v4.3.1` — both use Node.js 24, eliminating the Node.js 20 deprecation warning

## Test plan
- [ ] Build passes locally (`dotnet build --configuration Release` — 0 errors, 0 warnings)
- [ ] Pack passes locally (`dotnet pack` produces `NexJob.0.1.0.nupkg` without icon error)
- [ ] After merge: delete and recreate `v0.1.0` tag to trigger publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)