### PR TITLE
fix: include README.md in all packages and upgrade CI to Node.js 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,8 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-dotnet@v4.3.1
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-dotnet@v5.2.0
         with:
           dotnet-version: 8.0.x
       - run: dotnet restore
@@ -23,8 +23,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-dotnet@v4.3.1
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-dotnet@v5.2.0
         with:
           dotnet-version: 8.0.x
       - name: Extract version from tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,30 +35,14 @@ jobs:
           dotnet restore
           dotnet build --no-restore --configuration Release
       - name: Pack
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
-          dotnet pack src/NexJob/NexJob.csproj \
-            --no-build --configuration Release \
-            -p:VersionPrefix=${{ steps.version.outputs.VERSION }} \
-            -p:VersionSuffix= \
-            --output ./nupkg
-          dotnet pack src/NexJob.Postgres/NexJob.Postgres.csproj \
-            --no-build --configuration Release \
-            -p:VersionPrefix=${{ steps.version.outputs.VERSION }} \
-            -p:VersionSuffix= \
-            --output ./nupkg
-          dotnet pack src/NexJob.MongoDB/NexJob.MongoDB.csproj \
-            --no-build --configuration Release \
-            -p:VersionPrefix=${{ steps.version.outputs.VERSION }} \
-            -p:VersionSuffix= \
-            --output ./nupkg
-          dotnet pack src/NexJob.Dashboard/NexJob.Dashboard.csproj \
-            --no-build --configuration Release \
-            -p:VersionPrefix=${{ steps.version.outputs.VERSION }} \
-            -p:VersionSuffix= \
-            --output ./nupkg
+          dotnet pack src/NexJob/NexJob.csproj --no-build --configuration Release -p:VersionPrefix="$VERSION" -p:VersionSuffix= --output ./nupkg
+          dotnet pack src/NexJob.Postgres/NexJob.Postgres.csproj --no-build --configuration Release -p:VersionPrefix="$VERSION" -p:VersionSuffix= --output ./nupkg
+          dotnet pack src/NexJob.MongoDB/NexJob.MongoDB.csproj --no-build --configuration Release -p:VersionPrefix="$VERSION" -p:VersionSuffix= --output ./nupkg
+          dotnet pack src/NexJob.Dashboard/NexJob.Dashboard.csproj --no-build --configuration Release -p:VersionPrefix="$VERSION" -p:VersionSuffix= --output ./nupkg
       - name: Push to NuGet.org
-        run: |
-          dotnet nuget push ./nupkg/*.nupkg \
-            --api-key ${{ secrets.NUGET_API_KEY }} \
-            --source https://api.nuget.org/v3/index.json \
-            --skip-duplicate
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push "./nupkg/*.nupkg" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/src/NexJob.Dashboard/NexJob.Dashboard.csproj
+++ b/src/NexJob.Dashboard/NexJob.Dashboard.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\NexJob\NexJob.csproj" />
   </ItemGroup>

--- a/src/NexJob.MongoDB/NexJob.MongoDB.csproj
+++ b/src/NexJob.MongoDB/NexJob.MongoDB.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>NexJob.MongoDB.Tests</_Parameter1>
     </AssemblyAttribute>

--- a/src/NexJob.Postgres/NexJob.Postgres.csproj
+++ b/src/NexJob.Postgres/NexJob.Postgres.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>NexJob.Postgres.Tests</_Parameter1>
     </AssemblyAttribute>


### PR DESCRIPTION
## Summary
- Added `README.md` as a pack item to `NexJob.Postgres`, `NexJob.MongoDB`, and `NexJob.Dashboard` csproj files — `PackageReadmeFile` in `Directory.Build.props` declares the metadata but each project must also include the file explicitly
- Upgraded `actions/checkout` to `v6.0.2` and `actions/setup-dotnet` to `v5.2.0` (both use Node.js 24, eliminating the deprecation warning)

## Test plan
- [ ] All 4 `dotnet pack` commands succeed locally with no warnings
- [ ] After merge: retag `v0.1.0` to trigger publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)