### PR TITLE
docs: add coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [![NuGet](https://img.shields.io/nuget/v/NexJob.svg?style=flat-square&color=512bd4&label=nuget)](https://www.nuget.org/packages/NexJob)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/NexJob?style=flat-square&color=512bd4)](https://www.nuget.org/packages/NexJob)
 [![Build](https://img.shields.io/github/actions/workflow/status/oluciano/NexJob/ci.yml?style=flat-square)](https://github.com/oluciano/NexJob/actions)
+[![Coverage](https://img.shields.io/badge/coverage-87%25-brightgreen?style=flat-square)](https://github.com/oluciano/NexJob/actions)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg?style=flat-square)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-8.0%2B-512bd4?style=flat-square)](https://dotnet.microsoft.com)
 


### PR DESCRIPTION
Adds coverage badge (87%) alongside the existing NuGet, build, license, and .NET badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)