### PR TITLE
feat: v0.3 missing sections — AddNexJobJobs, MigrationPipeline, OpenTelemetry, HealthCheck, integration tests

### DIFF
--- a/samples/NexJob.Sample.WebApi/Program.cs
+++ b/samples/NexJob.Sample.WebApi/Program.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using NexJob;
 using NexJob.Dashboard;
 using NexJob.Sample.WebApi.Jobs;
@@ -12,12 +13,7 @@ builder.Services.AddNexJob(builder.Configuration, opt =>
     opt.MaxAttempts = 1; // fail fast for demo (dead-letters immediately)
 });
 
-builder.Services.AddTransient<SendEmailJob>();
-builder.Services.AddTransient<BulkEmailJob>();
-builder.Services.AddTransient<GenerateReportJob>();
-builder.Services.AddTransient<CleanupJob>();
-builder.Services.AddTransient<FlakeyJob>();
-builder.Services.AddTransient<SlowJob>();
+builder.Services.AddNexJobJobs(typeof(SendEmailJob).Assembly);
 
 var app = builder.Build();
 

--- a/src/NexJob/Internal/DefaultScheduler.cs
+++ b/src/NexJob/Internal/DefaultScheduler.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using System.Text.Json;
 using Cronos;
 using NexJob.Storage;
+using NexJob.Telemetry;
 
 namespace NexJob.Internal;
 
@@ -25,7 +27,7 @@ internal sealed class DefaultScheduler : IScheduler
     }
 
     /// <inheritdoc/>
-    public Task<JobId> EnqueueAsync<TJob, TInput>(
+    public async Task<JobId> EnqueueAsync<TJob, TInput>(
         TInput input,
         string? queue = null,
         JobPriority priority = JobPriority.Normal,
@@ -36,7 +38,14 @@ internal sealed class DefaultScheduler : IScheduler
         var job = BuildJobRecord<TJob, TInput>(input, queue, priority, idempotencyKey,
             status: JobStatus.Enqueued, scheduledAt: null);
 
-        return _storage.EnqueueAsync(job, cancellationToken);
+        using var activity = NexJobActivitySource.StartEnqueue(typeof(TJob).FullName ?? typeof(TJob).Name, job.Queue);
+
+        var jobId = await _storage.EnqueueAsync(job, cancellationToken);
+
+        activity?.SetTag("nexjob.job_id", jobId.Value.ToString());
+        NexJobMetrics.JobsEnqueued.Add(1, new TagList { { "nexjob.job_type", typeof(TJob).Name }, { "nexjob.queue", job.Queue } });
+
+        return jobId;
     }
 
     /// <inheritdoc/>
@@ -110,6 +119,8 @@ internal sealed class DefaultScheduler : IScheduler
         CancellationToken cancellationToken = default)
         where TJob : IJob<TInput>
     {
+        var traceParent = Activity.Current?.Id;
+
         var job = new JobRecord
         {
             Id = JobId.New(),
@@ -122,6 +133,7 @@ internal sealed class DefaultScheduler : IScheduler
             ParentJobId = parentJobId,
             CreatedAt = DateTimeOffset.UtcNow,
             MaxAttempts = _options.MaxAttempts,
+            TraceParent = traceParent,
         };
 
         return await _storage.EnqueueAsync(job, cancellationToken);

--- a/src/NexJob/Internal/JobDispatcherService.cs
+++ b/src/NexJob/Internal/JobDispatcherService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json;
@@ -7,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NexJob.Configuration;
 using NexJob.Storage;
+using NexJob.Telemetry;
 
 namespace NexJob.Internal;
 
@@ -162,6 +164,10 @@ internal sealed class JobDispatcherService : BackgroundService
         // Each job task has its own async context; the scope captures all log entries
         // emitted by any category within this execution without affecting other concurrent jobs.
         using var logScope = new JobExecutionLogScope(_options.MaxJobLogLines);
+        using var activity = NexJobActivitySource.StartExecute(job.JobType, job.Queue, job.TraceParent);
+        activity?.SetTag("nexjob.job_id", job.Id.Value.ToString());
+        activity?.SetTag("nexjob.attempt", job.Attempts);
+        var sw = Stopwatch.StartNew();
 
         try
         {
@@ -169,7 +175,14 @@ internal sealed class JobDispatcherService : BackgroundService
 
             var jobType = Type.GetType(job.JobType, throwOnError: true)!;
             var inputType = Type.GetType(job.InputType, throwOnError: true)!;
-            var input = JsonSerializer.Deserialize(job.InputJson, inputType)
+
+            // Apply migration pipeline if payload schema version is outdated
+            var currentVersion = jobType.GetCustomAttribute<SchemaVersionAttribute>()?.Version ?? 1;
+            var migratedJson = scope.ServiceProvider
+                .GetRequiredService<MigrationPipeline>()
+                .Migrate(job.InputJson, job.SchemaVersion, currentVersion, inputType);
+
+            var input = JsonSerializer.Deserialize(migratedJson, inputType)
                         ?? throw new InvalidOperationException($"Deserialized null input for job {job.Id}.");
 
             var jobInstance = scope.ServiceProvider.GetRequiredService(jobType);
@@ -198,6 +211,11 @@ internal sealed class JobDispatcherService : BackgroundService
                 }
             }
 
+            sw.Stop();
+            NexJobMetrics.JobDuration.Record(sw.Elapsed.TotalMilliseconds, new TagList { { "nexjob.job_type", job.JobType }, { "nexjob.status", "succeeded" } });
+            NexJobMetrics.JobsSucceeded.Add(1, new TagList { { "nexjob.job_type", job.JobType } });
+            activity?.SetStatus(ActivityStatusCode.Ok);
+
             await _storage.AcknowledgeAsync(job.Id, CancellationToken.None);
             await _storage.SaveExecutionLogsAsync(job.Id, logScope.Entries, CancellationToken.None);
             await _storage.EnqueueContinuationsAsync(job.Id, CancellationToken.None);
@@ -218,6 +236,15 @@ internal sealed class JobDispatcherService : BackgroundService
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Job {JobId} failed on attempt {Attempt}", job.Id, job.Attempts);
+
+            NexJobMetrics.JobsFailed.Add(1, new TagList { { "nexjob.job_type", job.JobType } });
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
+            {
+                { "exception.type", ex.GetType().FullName },
+                { "exception.message", ex.Message },
+                { "exception.stacktrace", ex.StackTrace },
+            }));
 
             DateTimeOffset? retryAt = null;
 

--- a/src/NexJob/Internal/MigrationDescriptor.cs
+++ b/src/NexJob/Internal/MigrationDescriptor.cs
@@ -1,0 +1,21 @@
+namespace NexJob.Internal;
+
+/// <summary>
+/// Describes a registered migration pair used by <see cref="MigrationPipeline"/>
+/// to resolve migration chains without open-generic service lookups.
+/// </summary>
+internal sealed class MigrationDescriptor
+{
+    /// <summary>Initializes a new <see cref="MigrationDescriptor"/>.</summary>
+    public MigrationDescriptor(Type oldType, Type newType)
+    {
+        OldType = oldType;
+        NewType = newType;
+    }
+
+    /// <summary>Gets the source (old) input type for this migration step.</summary>
+    public Type OldType { get; }
+
+    /// <summary>Gets the target (new) input type for this migration step.</summary>
+    public Type NewType { get; }
+}

--- a/src/NexJob/Internal/MigrationPipeline.cs
+++ b/src/NexJob/Internal/MigrationPipeline.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace NexJob.Internal;
+
+/// <summary>
+/// Resolves and applies a chain of <see cref="IJobMigration{TOld,TNew}"/> instances to
+/// upgrade a serialized job payload from its stored schema version to the current one.
+/// </summary>
+internal sealed class MigrationPipeline
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IEnumerable<MigrationDescriptor> _descriptors;
+
+    /// <summary>Initializes a new <see cref="MigrationPipeline"/>.</summary>
+    public MigrationPipeline(IServiceProvider serviceProvider, IEnumerable<MigrationDescriptor> descriptors)
+    {
+        _serviceProvider = serviceProvider;
+        _descriptors = descriptors;
+    }
+
+    /// <summary>
+    /// Migrates <paramref name="inputJson"/> from <paramref name="storedVersion"/> to
+    /// <paramref name="currentVersion"/> by resolving and invoking each
+    /// <see cref="IJobMigration{TOld,TNew}"/> registered in the DI container.
+    /// Returns the original JSON unchanged if the stored version matches the current version
+    /// or if no migrations are required.
+    /// </summary>
+    /// <param name="inputJson">The raw JSON payload stored with the job.</param>
+    /// <param name="storedVersion">The schema version stored alongside the job payload.</param>
+    /// <param name="currentVersion">The version declared by <see cref="SchemaVersionAttribute"/> on the job class (or 1 if absent).</param>
+    /// <param name="inputType">The current (target) input type the job expects.</param>
+    /// <returns>A JSON string representing the migrated payload at the current version.</returns>
+    public string Migrate(string inputJson, int storedVersion, int currentVersion, Type inputType)
+    {
+        if (storedVersion >= currentVersion)
+        {
+            return inputJson;
+        }
+
+        var migrations = BuildChain(storedVersion, currentVersion, inputType);
+
+        if (migrations.Count == 0)
+        {
+            return inputJson;
+        }
+
+        var migrationInterfaceType = typeof(IJobMigration<,>);
+
+        // Determine the starting type from the first migration's TOld
+        var firstIface = migrations[0].GetType().GetInterfaces()
+            .First(i => i.IsGenericType && i.GetGenericTypeDefinition() == migrationInterfaceType);
+        var currentType = firstIface.GetGenericArguments()[0];
+
+        object? payload = JsonSerializer.Deserialize(inputJson, currentType)
+                          ?? throw new InvalidOperationException($"Failed to deserialize payload as {currentType.Name}.");
+
+        foreach (var migration in migrations)
+        {
+            var migrateMethod = migration.GetType().GetMethod("Migrate")!;
+            payload = migrateMethod.Invoke(migration, [payload])!;
+        }
+
+        return JsonSerializer.Serialize(payload, inputType);
+    }
+
+    private List<object> BuildChain(int storedVersion, int currentVersion, Type targetInputType)
+    {
+        var migrationInterfaceType = typeof(IJobMigration<,>);
+        var chain = new List<object>();
+        var currentTargetType = targetInputType;
+
+        for (var version = currentVersion; version > storedVersion; version--)
+        {
+            var descriptor = _descriptors
+                .ToList()
+                .Find(d => d.NewType == currentTargetType);
+
+            if (descriptor is null)
+            {
+                break;
+            }
+
+            var closedMigrationType = migrationInterfaceType.MakeGenericType(descriptor.OldType, descriptor.NewType);
+            var migration = _serviceProvider.GetService(closedMigrationType);
+
+            if (migration is null)
+            {
+                break;
+            }
+
+            chain.Insert(0, migration);
+            currentTargetType = descriptor.OldType;
+        }
+
+        return chain;
+    }
+}

--- a/src/NexJob/JobRecord.cs
+++ b/src/NexJob/JobRecord.cs
@@ -98,6 +98,13 @@ public sealed class JobRecord
     /// </summary>
     public string? RecurringJobId { get; init; }
 
+    /// <summary>
+    /// W3C traceparent header value captured at enqueue time.
+    /// Used by <see cref="NexJob.Telemetry.NexJobActivitySource"/> to restore the distributed
+    /// trace context when the job is executed, linking execution spans back to the enqueue span.
+    /// </summary>
+    public string? TraceParent { get; init; }
+
     /// <summary>Log entries captured during the last execution of this job.</summary>
     public IReadOnlyList<JobExecutionLog> ExecutionLogs { get; set; } = Array.Empty<JobExecutionLog>();
 }

--- a/src/NexJob/NexJob.csproj
+++ b/src/NexJob/NexJob.csproj
@@ -25,8 +25,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/NexJob/NexJobHealthCheck.cs
+++ b/src/NexJob/NexJobHealthCheck.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NexJob.Storage;
+
+namespace NexJob;
+
+/// <summary>
+/// Health check for the NexJob background job system.
+/// Reports <see cref="HealthStatus.Healthy"/> when the storage layer responds within 2 seconds,
+/// <see cref="HealthStatus.Degraded"/> when the dead-letter (failed) count exceeds
+/// <see cref="FailedJobThreshold"/>, and <see cref="HealthStatus.Unhealthy"/> when the
+/// storage is unreachable.
+/// </summary>
+public sealed class NexJobHealthCheck : IHealthCheck
+{
+    private readonly IStorageProvider _storage;
+
+    /// <summary>Initializes a new <see cref="NexJobHealthCheck"/>.</summary>
+    public NexJobHealthCheck(IStorageProvider storage)
+    {
+        _storage = storage;
+    }
+
+    /// <summary>
+    /// Number of failed (dead-letter) jobs above which the check reports
+    /// <see cref="HealthStatus.Degraded"/>. Defaults to <c>100</c>.
+    /// </summary>
+    public static int FailedJobThreshold { get; set; } = 100;
+
+    /// <inheritdoc/>
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(2));
+
+            var metrics = await _storage.GetMetricsAsync(cts.Token);
+
+            var data = new Dictionary<string, object>
+            {
+                ["enqueued"] = metrics.Enqueued,
+                ["processing"] = metrics.Processing,
+                ["succeeded"] = metrics.Succeeded,
+                ["failed"] = metrics.Failed,
+                ["scheduled"] = metrics.Scheduled,
+                ["recurring"] = metrics.Recurring,
+            };
+
+            if (metrics.Failed > FailedJobThreshold)
+            {
+                return HealthCheckResult.Degraded(
+                    $"Dead-letter queue contains {metrics.Failed} failed jobs (threshold: {FailedJobThreshold}).",
+                    data: data);
+            }
+
+            return HealthCheckResult.Healthy("NexJob storage is responsive.", data);
+        }
+        catch (OperationCanceledException)
+        {
+            return HealthCheckResult.Unhealthy("NexJob storage did not respond within 2 seconds.");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("NexJob storage is unreachable.", ex);
+        }
+    }
+}

--- a/src/NexJob/NexJobHealthCheckExtensions.cs
+++ b/src/NexJob/NexJobHealthCheckExtensions.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace NexJob;
+
+/// <summary>
+/// Extension methods for registering the NexJob health check.
+/// </summary>
+public static class NexJobHealthCheckExtensions
+{
+    /// <summary>
+    /// Adds the <see cref="NexJobHealthCheck"/> to the health check pipeline.
+    /// </summary>
+    /// <param name="builder">The health checks builder.</param>
+    /// <param name="name">The health check name. Defaults to <c>nexjob</c>.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> to report when unhealthy.
+    /// Defaults to <see cref="HealthStatus.Unhealthy"/>.
+    /// </param>
+    /// <param name="tags">Optional tags to associate with the health check.</param>
+    /// <returns>The original builder for chaining.</returns>
+    public static IHealthChecksBuilder AddNexJob(
+        this IHealthChecksBuilder builder,
+        string name = "nexjob",
+        HealthStatus failureStatus = HealthStatus.Unhealthy,
+        IEnumerable<string>? tags = null)
+    {
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => sp.GetRequiredService<NexJobHealthCheck>(),
+            failureStatus,
+            tags));
+    }
+}

--- a/src/NexJob/NexJobServiceCollectionExtensions.cs
+++ b/src/NexJob/NexJobServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -68,6 +69,52 @@ public static class NexJobServiceCollectionExtensions
         return RegisterCore(services, options);
     }
 
+    /// <summary>
+    /// Scans <paramref name="assembly"/> for all non-abstract classes implementing
+    /// <see cref="IJob{TInput}"/> and registers each one as <c>Transient</c>.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="assembly">The assembly to scan.</param>
+    /// <returns>The original <paramref name="services"/> for chaining.</returns>
+    public static IServiceCollection AddNexJobJobs(
+        this IServiceCollection services,
+        Assembly assembly)
+    {
+        var jobInterfaceType = typeof(IJob<>);
+
+        var jobTypes = assembly.GetTypes()
+            .Where(t => t is { IsAbstract: false, IsClass: true }
+                && Array.Exists(t.GetInterfaces(), i =>
+                    i.IsGenericType && i.GetGenericTypeDefinition() == jobInterfaceType));
+
+        foreach (var jobType in jobTypes)
+        {
+            services.TryAddTransient(jobType);
+        }
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="IJobMigration{TOld,TNew}"/> implementation and its
+    /// associated <see cref="NexJob.Internal.MigrationDescriptor"/> so that
+    /// <see cref="NexJob.Internal.MigrationPipeline"/> can automatically upgrade
+    /// stored payloads when a job's input type changes between versions.
+    /// </summary>
+    /// <typeparam name="TOld">The previous (source) input type.</typeparam>
+    /// <typeparam name="TNew">The current (target) input type.</typeparam>
+    /// <typeparam name="TMigration">The migration implementation.</typeparam>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The original <paramref name="services"/> for chaining.</returns>
+    public static IServiceCollection AddJobMigration<TOld, TNew, TMigration>(
+        this IServiceCollection services)
+        where TMigration : class, IJobMigration<TOld, TNew>
+    {
+        services.AddTransient<IJobMigration<TOld, TNew>, TMigration>();
+        services.AddSingleton(new MigrationDescriptor(typeof(TOld), typeof(TNew)));
+        return services;
+    }
+
     // ── private helpers ───────────────────────────────────────────────────────
 
     private static NexJobOptions BuildFromConfiguration(IConfiguration configuration)
@@ -97,6 +144,8 @@ public static class NexJobServiceCollectionExtensions
         services.AddHostedService<JobDispatcherService>();
         services.AddHostedService<RecurringJobSchedulerService>();
         services.AddHostedService<OrphanedJobWatcherService>();
+        services.AddScoped<MigrationPipeline>();
+        services.AddScoped<NexJobHealthCheck>();
 
         return services;
     }

--- a/src/NexJob/SchemaVersionAttribute.cs
+++ b/src/NexJob/SchemaVersionAttribute.cs
@@ -1,0 +1,29 @@
+namespace NexJob;
+
+/// <summary>
+/// Declares the current schema version of a job's input payload.
+/// Apply this attribute to an <see cref="IJob{TInput}"/> implementation to participate
+/// in the automatic migration pipeline. When absent, version 1 is assumed.
+/// </summary>
+/// <example>
+/// <code>
+/// [SchemaVersion(2)]
+/// public class SendEmailJob : IJob&lt;SendEmailInputV2&gt; { ... }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class SchemaVersionAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new <see cref="SchemaVersionAttribute"/>.
+    /// </summary>
+    /// <param name="version">The current schema version. Must be greater than or equal to 1.</param>
+    public SchemaVersionAttribute(int version)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(version, 1);
+        Version = version;
+    }
+
+    /// <summary>Gets the declared schema version.</summary>
+    public int Version { get; }
+}

--- a/src/NexJob/Telemetry/NexJobActivitySource.cs
+++ b/src/NexJob/Telemetry/NexJobActivitySource.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace NexJob.Telemetry;
+
+/// <summary>
+/// Provides the shared <see cref="ActivitySource"/> and W3C TraceContext propagation
+/// helpers used throughout NexJob's instrumentation.
+/// </summary>
+public static class NexJobActivitySource
+{
+    /// <summary>The name of the NexJob activity source, for use with OpenTelemetry SDK configuration.</summary>
+    public const string Name = "NexJob";
+
+    internal static readonly ActivitySource Source =
+        new(Name, Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0");
+
+    /// <summary>
+    /// Starts a new <see cref="Activity"/> for a job enqueue operation.
+    /// Returns <see langword="null"/> when no listener is subscribed.
+    /// </summary>
+    /// <param name="jobType">The fully-qualified job type name.</param>
+    /// <param name="queue">The target queue name.</param>
+    internal static Activity? StartEnqueue(string jobType, string queue) =>
+        Source.StartActivity(
+            "nexjob.enqueue",
+            ActivityKind.Producer,
+            parentContext: default,
+            tags:
+            [
+                new("nexjob.job_type", jobType),
+                new("nexjob.queue", queue),
+            ]);
+
+    /// <summary>
+    /// Starts a new <see cref="Activity"/> for a job execution span, optionally
+    /// restoring a parent trace context propagated from the enqueue call.
+    /// </summary>
+    /// <param name="jobType">The fully-qualified job type name.</param>
+    /// <param name="queue">The queue the job was fetched from.</param>
+    /// <param name="traceParent">W3C traceparent header value stored at enqueue time, or <see langword="null"/>.</param>
+    internal static Activity? StartExecute(string jobType, string queue, string? traceParent)
+    {
+        ActivityContext parentContext = default;
+
+        if (traceParent is not null)
+        {
+            ActivityContext.TryParse(traceParent, null, out parentContext);
+        }
+
+        return Source.StartActivity(
+            "nexjob.execute",
+            ActivityKind.Consumer,
+            parentContext,
+            tags:
+            [
+                new("nexjob.job_type", jobType),
+                new("nexjob.queue", queue),
+            ]);
+    }
+}

--- a/src/NexJob/Telemetry/NexJobMetrics.cs
+++ b/src/NexJob/Telemetry/NexJobMetrics.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics.Metrics;
+using System.Reflection;
+
+namespace NexJob.Telemetry;
+
+/// <summary>
+/// Exposes the NexJob <see cref="Meter"/> and its instruments.
+/// Register with the OpenTelemetry SDK via <c>AddMeter(NexJobMetrics.MeterName)</c>.
+/// </summary>
+public static class NexJobMetrics
+{
+    /// <summary>The meter name for use with the OpenTelemetry SDK.</summary>
+    public const string MeterName = "NexJob";
+
+    internal static readonly Meter Meter =
+        new(MeterName, Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0");
+
+    /// <summary>Counts jobs enqueued.</summary>
+    internal static readonly Counter<long> JobsEnqueued =
+        Meter.CreateCounter<long>("nexjob.jobs.enqueued", "jobs", "Number of jobs enqueued.");
+
+    /// <summary>Counts jobs completed successfully.</summary>
+    internal static readonly Counter<long> JobsSucceeded =
+        Meter.CreateCounter<long>("nexjob.jobs.succeeded", "jobs", "Number of jobs completed successfully.");
+
+    /// <summary>Counts jobs that failed (including those moved to dead-letter).</summary>
+    internal static readonly Counter<long> JobsFailed =
+        Meter.CreateCounter<long>("nexjob.jobs.failed", "jobs", "Number of jobs that failed.");
+
+    /// <summary>Records job execution duration in milliseconds.</summary>
+    internal static readonly Histogram<double> JobDuration =
+        Meter.CreateHistogram<double>("nexjob.job.duration", "ms", "Job execution duration in milliseconds.");
+}

--- a/tests/NexJob.IntegrationTests/NexJob.IntegrationTests.csproj
+++ b/tests/NexJob.IntegrationTests/NexJob.IntegrationTests.csproj
@@ -10,6 +10,8 @@
     <ProjectReference Include="..\..\src\NexJob\NexJob.csproj" />
     <ProjectReference Include="..\..\src\NexJob.Postgres\NexJob.Postgres.csproj" />
     <ProjectReference Include="..\..\src\NexJob.MongoDB\NexJob.MongoDB.csproj" />
+    <ProjectReference Include="..\..\src\NexJob.Redis\NexJob.Redis.csproj" />
+    <ProjectReference Include="..\..\src\NexJob.SqlServer\NexJob.SqlServer.csproj" />
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
@@ -17,6 +19,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.10.0" />
     <PackageReference Include="Testcontainers.MongoDb" Version="3.10.0" />
+    <PackageReference Include="Testcontainers.Redis" Version="3.10.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="3.10.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/NexJob.IntegrationTests/RedisStorageProviderTests.cs
+++ b/tests/NexJob.IntegrationTests/RedisStorageProviderTests.cs
@@ -1,0 +1,29 @@
+using NexJob.Redis;
+using NexJob.Storage;
+using Testcontainers.Redis;
+using Xunit;
+
+namespace NexJob.IntegrationTests;
+
+/// <summary>
+/// Runs the full <see cref="StorageProviderTestsBase"/> contract against a real
+/// Redis instance spun up via Testcontainers.
+/// Requires Docker to be available on the host.
+/// </summary>
+public sealed class RedisStorageProviderTests : StorageProviderTestsBase, IAsyncLifetime
+{
+    private readonly RedisContainer _container = new RedisBuilder()
+        .WithImage("redis:7-alpine")
+        .Build();
+
+    public async Task InitializeAsync() => await _container.StartAsync();
+
+    public async Task DisposeAsync() => await _container.DisposeAsync();
+
+    protected override Task<IStorageProvider> CreateStorageAsync() =>
+        Task.FromResult<IStorageProvider>(
+            new RedisStorageProvider(
+                StackExchange.Redis.ConnectionMultiplexer
+                    .Connect(_container.GetConnectionString())
+                    .GetDatabase()));
+}

--- a/tests/NexJob.IntegrationTests/SqlServerStorageProviderTests.cs
+++ b/tests/NexJob.IntegrationTests/SqlServerStorageProviderTests.cs
@@ -1,0 +1,26 @@
+using NexJob.SqlServer;
+using NexJob.Storage;
+using Testcontainers.MsSql;
+using Xunit;
+
+namespace NexJob.IntegrationTests;
+
+/// <summary>
+/// Runs the full <see cref="StorageProviderTestsBase"/> contract against a real
+/// SQL Server instance spun up via Testcontainers.
+/// Requires Docker to be available on the host.
+/// </summary>
+public sealed class SqlServerStorageProviderTests : StorageProviderTestsBase, IAsyncLifetime
+{
+    private readonly MsSqlContainer _container = new MsSqlBuilder()
+        .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+        .Build();
+
+    public async Task InitializeAsync() => await _container.StartAsync();
+
+    public async Task DisposeAsync() => await _container.DisposeAsync();
+
+    protected override Task<IStorageProvider> CreateStorageAsync() =>
+        Task.FromResult<IStorageProvider>(
+            new SqlServerStorageProvider(_container.GetConnectionString()));
+}

--- a/tests/NexJob.Tests/MigrationPipelineTests.cs
+++ b/tests/NexJob.Tests/MigrationPipelineTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NexJob.Internal;
+using Xunit;
+
+namespace NexJob.Tests;
+
+public sealed class MigrationPipelineTests
+{
+    // ─── helpers ──────────────────────────────────────────────────────────────
+
+    private static MigrationPipeline BuildPipeline(Action<IServiceCollection>? configure = null)
+    {
+        var services = new ServiceCollection();
+        configure?.Invoke(services);
+        var sp = services.BuildServiceProvider();
+        return new MigrationPipeline(sp, sp.GetServices<MigrationDescriptor>());
+    }
+
+    // ─── no migration needed ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Migrate_WhenVersionsMatch_ReturnsOriginalJson()
+    {
+        var pipeline = BuildPipeline();
+        const string json = "{\"Value\":42}";
+
+        var result = pipeline.Migrate(json, storedVersion: 1, currentVersion: 1, typeof(V1Payload));
+
+        result.Should().Be(json);
+    }
+
+    [Fact]
+    public void Migrate_WhenStoredVersionAhead_ReturnsOriginalJson()
+    {
+        var pipeline = BuildPipeline();
+        const string json = "{\"Value\":42}";
+
+        var result = pipeline.Migrate(json, storedVersion: 3, currentVersion: 2, typeof(V2Payload));
+
+        result.Should().Be(json);
+    }
+
+    // ─── single migration ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Migrate_WithOneMigration_UpgradesPayload()
+    {
+        var pipeline = BuildPipeline(s =>
+        {
+            s.AddSingleton<IJobMigration<V1Payload, V2Payload>>(new V1ToV2Migration());
+            s.AddSingleton(new MigrationDescriptor(typeof(V1Payload), typeof(V2Payload)));
+        });
+
+        const string json = "{\"OldName\":\"hello\"}";
+
+        var result = pipeline.Migrate(json, storedVersion: 1, currentVersion: 2, typeof(V2Payload));
+
+        result.Should().Contain("NewName");
+        result.Should().Contain("hello");
+    }
+
+    // ─── no migration registered ──────────────────────────────────────────────
+
+    [Fact]
+    public void Migrate_WithNoMigrationRegistered_ReturnsOriginalJson()
+    {
+        var pipeline = BuildPipeline();
+        const string json = "{\"OldName\":\"hello\"}";
+
+        var result = pipeline.Migrate(json, storedVersion: 1, currentVersion: 2, typeof(V2Payload));
+
+        result.Should().Be(json);
+    }
+}
+
+// ─── Stub types ───────────────────────────────────────────────────────────────
+
+public sealed class V1Payload
+{
+    public int Value { get; set; }
+
+    public string OldName { get; set; } = string.Empty;
+}
+
+public sealed class V2Payload
+{
+    public int Value { get; set; }
+
+    public string NewName { get; set; } = string.Empty;
+}
+
+public sealed class V1ToV2Migration : IJobMigration<V1Payload, V2Payload>
+{
+    public V2Payload Migrate(V1Payload old) =>
+        new V2Payload { Value = old.Value, NewName = old.OldName };
+}


### PR DESCRIPTION
## Summary

Implements the 5 missing sections from the v0.3 work order:

- **SEÇÃO 0 — `AddNexJobJobs(Assembly)`**: scans assembly for all `IJob<TInput>` implementors and registers them as Transient; `AddJobMigration<TOld,TNew,TMigration>()` helper added; sample WebApi switched from 6 manual `AddTransient` calls to one `AddNexJobJobs(assembly)` call

- **SEÇÃO 6 — Integration tests**: `RedisStorageProviderTests` and `SqlServerStorageProviderTests` — both inherit `StorageProviderTestsBase`, spun up via Testcontainers (Redis 7-alpine, SQL Server 2022); packages added to IntegrationTests csproj

- **SEÇÃO 7 — MigrationPipeline**: `[SchemaVersion(n)]` attribute on job classes; `MigrationPipeline` resolves `IJobMigration<TOld,TNew>` chains via `MigrationDescriptor` registrations; integrated into `JobDispatcherService` before deserialization; 4 unit tests

- **SEÇÃO 8 — OpenTelemetry**: `NexJobActivitySource` (nexjob.enqueue + nexjob.execute spans); `NexJobMetrics` (enqueued/succeeded/failed counters + duration histogram); `JobRecord.TraceParent` for W3C context propagation enqueue → execute; `DefaultScheduler` and `JobDispatcherService` fully instrumented

- **SEÇÃO 9 — Health check**: `NexJobHealthCheck` (Healthy < 2s, Degraded when failed > threshold, Unhealthy on error); `services.AddHealthChecks().AddNexJob()` extension

## Test plan

- [x] `dotnet build --configuration Release` → 0 warnings, 0 errors
- [x] `dotnet test tests/NexJob.Tests/` → 104/104 passing
- [x] `dotnet format --verify-no-changes --severity warn` → clean
- [ ] `dotnet test tests/NexJob.IntegrationTests/` → requires Docker (Redis + SQL Server containers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)