### PR TITLE
feat: graceful shutdown, [Retry] attribute, versioned schema migrations, distributed recurring locks

### DIFF
--- a/src/NexJob.MongoDB/MongoStorageProvider.cs
+++ b/src/NexJob.MongoDB/MongoStorageProvider.cs
@@ -16,6 +16,7 @@ public sealed class MongoStorageProvider : IStorageProvider
 {
     private readonly IMongoCollection<JobDocument> _jobs;
     private readonly IMongoCollection<RecurringJobDocument> _recurringJobs;
+    private readonly IMongoCollection<BsonDocument> _recurringLocks;
 
     static MongoStorageProvider()
     {
@@ -36,6 +37,7 @@ public sealed class MongoStorageProvider : IStorageProvider
     {
         _jobs = database.GetCollection<JobDocument>("nexjob_jobs");
         _recurringJobs = database.GetCollection<RecurringJobDocument>("nexjob_recurring_jobs");
+        _recurringLocks = database.GetCollection<BsonDocument>("nexjob_recurring_locks");
 
         EnsureIndexes();
     }
@@ -470,6 +472,41 @@ public sealed class MongoStorageProvider : IStorageProvider
         await _jobs.UpdateOneAsync(ById(jobId), update, cancellationToken: cancellationToken);
     }
 
+    /// <inheritdoc/>
+    public async Task<bool> TryAcquireRecurringJobLockAsync(
+        string recurringJobId, TimeSpan ttl, CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var expiry = now.Add(ttl);
+
+        // Delete expired lock first
+        await _recurringLocks.DeleteOneAsync(
+            Builders<BsonDocument>.Filter.And(
+                Builders<BsonDocument>.Filter.Eq("_id", recurringJobId),
+                Builders<BsonDocument>.Filter.Lt("expires_at", now)),
+            ct);
+
+        try
+        {
+            await _recurringLocks.InsertOneAsync(
+                new BsonDocument { ["_id"] = recurringJobId, ["expires_at"] = expiry },
+                cancellationToken: ct);
+            return true;
+        }
+        catch (MongoWriteException ex) when (ex.WriteError.Category == ServerErrorCategory.DuplicateKey)
+        {
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task ReleaseRecurringJobLockAsync(
+        string recurringJobId, CancellationToken ct = default)
+    {
+        await _recurringLocks.DeleteOneAsync(
+            Builders<BsonDocument>.Filter.Eq("_id", recurringJobId), ct);
+    }
+
     // ── Private helpers ───────────────────────────────────────────────────────
 
     private static FilterDefinition<JobDocument> ById(JobId id) =>
@@ -538,5 +575,10 @@ public sealed class MongoStorageProvider : IStorageProvider
             new CreateIndexOptions { Name = "next_execution" }));
 
         // RecurringJobId is [BsonId] — MongoDB already enforces unique on _id.
+
+        // TTL index on recurring locks — MongoDB removes expired documents automatically
+        _recurringLocks.Indexes.CreateOne(new CreateIndexModel<BsonDocument>(
+            Builders<BsonDocument>.IndexKeys.Ascending("expires_at"),
+            new CreateIndexOptions { ExpireAfter = TimeSpan.Zero }));
     }
 }

--- a/src/NexJob.Postgres/PostgresStorageProvider.cs
+++ b/src/NexJob.Postgres/PostgresStorageProvider.cs
@@ -16,8 +16,8 @@ public sealed class PostgresStorageProvider : IStorageProvider
     private readonly string _connectionString;
 
     /// <summary>
-    /// Initialises the provider and ensures the database schema exists.
-    /// Safe to call multiple times — all DDL statements use <c>IF NOT EXISTS</c>.
+    /// Initialises the provider and applies all pending schema migrations.
+    /// Acquires a PostgreSQL advisory lock so only one instance migrates at a time.
     /// </summary>
     public PostgresStorageProvider(string connectionString)
     {
@@ -25,7 +25,8 @@ public sealed class PostgresStorageProvider : IStorageProvider
         // Allow Dapper to match snake_case column names to PascalCase properties
         // (e.g., recurring_job_id → RecurringJobId, completed_at → CompletedAt)
         Dapper.DefaultTypeMap.MatchNamesWithUnderscores = true;
-        EnsureSchema();
+        // Sync-over-async is acceptable here: runs once at startup, before any requests are served.
+        new SchemaMigrator().MigrateAsync(connectionString).GetAwaiter().GetResult();
     }
 
     // ── EnqueueAsync ──────────────────────────────────────────────────────────
@@ -545,14 +546,36 @@ public sealed class PostgresStorageProvider : IStorageProvider
             new { Id = jobId.Value, Logs = JsonSerializer.Serialize(logs) });
     }
 
+    /// <inheritdoc/>
+    public async Task<bool> TryAcquireRecurringJobLockAsync(
+        string recurringJobId, TimeSpan ttl, CancellationToken ct = default)
+    {
+        await using var conn = Open();
+        await conn.OpenAsync(ct);
+        await conn.ExecuteAsync(
+            "DELETE FROM nexjob_recurring_locks WHERE expires_at < NOW()");
+        var rows = await conn.ExecuteAsync(
+            """
+            INSERT INTO nexjob_recurring_locks (recurring_job_id, expires_at)
+            VALUES (@id, NOW() + @ttl::interval)
+            ON CONFLICT (recurring_job_id) DO NOTHING
+            """,
+            new { id = recurringJobId, ttl = ttl.ToString() });
+        return rows > 0;
+    }
+
+    /// <inheritdoc/>
+    public async Task ReleaseRecurringJobLockAsync(
+        string recurringJobId, CancellationToken ct = default)
+    {
+        await using var conn = Open();
+        await conn.OpenAsync(ct);
+        await conn.ExecuteAsync(
+            "DELETE FROM nexjob_recurring_locks WHERE recurring_job_id = @id",
+            new { id = recurringJobId });
+    }
+
     // ── Schema ────────────────────────────────────────────────────────────────
 
     private NpgsqlConnection Open() => new(_connectionString);
-
-    private void EnsureSchema()
-    {
-        using var conn = Open();
-        conn.Open();
-        conn.Execute(SchemaSql.CreateTables);
-    }
 }

--- a/src/NexJob.Postgres/SchemaMigration.cs
+++ b/src/NexJob.Postgres/SchemaMigration.cs
@@ -1,0 +1,3 @@
+namespace NexJob.Postgres;
+
+internal sealed record SchemaMigration(int Version, string Description, string Sql);

--- a/src/NexJob.Postgres/SchemaMigrator.cs
+++ b/src/NexJob.Postgres/SchemaMigrator.cs
@@ -1,0 +1,83 @@
+using Dapper;
+using Npgsql;
+
+namespace NexJob.Postgres;
+
+/// <summary>
+/// Applies versioned DDL migrations to the PostgreSQL schema on startup.
+/// Uses <c>pg_advisory_lock</c> to prevent concurrent migration races when multiple
+/// instances start simultaneously.
+/// </summary>
+internal sealed class SchemaMigrator
+{
+    // Arbitrary but stable numeric key for pg_advisory_lock: hash of 'nexjob'
+    private const long AdvisoryLockKey = 7_242_374_305L;
+
+    private static readonly IReadOnlyList<SchemaMigration> Migrations =
+    [
+        new(1, "initial schema", SchemaSql.V1CreateTables),
+        new(2, "add recurring job config columns", SchemaSql.V2AlterRecurring),
+        new(3, "add execution_logs and trace_parent columns", SchemaSql.V3AddColumns),
+        new(4, "create schema_version and recurring_locks tables", SchemaSql.V4CreateVersionTable),
+    ];
+
+    /// <summary>
+    /// Runs all pending migrations against <paramref name="connectionString"/>.
+    /// Acquires a PostgreSQL advisory lock so only one instance migrates at a time.
+    /// </summary>
+    /// <param name="connectionString">The PostgreSQL connection string.</param>
+    /// <param name="ct">Token to cancel the operation.</param>
+    public async Task MigrateAsync(string connectionString, CancellationToken ct = default)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync(ct);
+
+        // Acquire advisory lock — blocks until acquired
+        await conn.ExecuteAsync($"SELECT pg_advisory_lock({AdvisoryLockKey})");
+
+        try
+        {
+            // Ensure version table exists (bootstrap: first ever run)
+            await conn.ExecuteAsync(
+                """
+                CREATE TABLE IF NOT EXISTS nexjob_schema_version (
+                    version     INT         PRIMARY KEY,
+                    applied_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    description TEXT        NOT NULL
+                )
+                """);
+
+            var applied = (await conn.QueryAsync<int>(
+                "SELECT version FROM nexjob_schema_version"))
+                .ToHashSet();
+
+            foreach (var migration in Migrations)
+            {
+                if (applied.Contains(migration.Version))
+                {
+                    continue;
+                }
+
+                await using var tx = await conn.BeginTransactionAsync(ct);
+                try
+                {
+                    await conn.ExecuteAsync(migration.Sql, transaction: tx);
+                    await conn.ExecuteAsync(
+                        "INSERT INTO nexjob_schema_version (version, description) VALUES (@v, @d)",
+                        new { v = migration.Version, d = migration.Description },
+                        transaction: tx);
+                    await tx.CommitAsync(ct);
+                }
+                catch
+                {
+                    await tx.RollbackAsync(ct);
+                    throw;
+                }
+            }
+        }
+        finally
+        {
+            await conn.ExecuteAsync($"SELECT pg_advisory_unlock({AdvisoryLockKey})");
+        }
+    }
+}

--- a/src/NexJob.Postgres/SchemaSQL.cs
+++ b/src/NexJob.Postgres/SchemaSQL.cs
@@ -2,7 +2,8 @@ namespace NexJob.Postgres;
 
 internal static class SchemaSql
 {
-    internal const string CreateTables =
+    /// <summary>V1: Initial schema — nexjob_jobs table, indexes, nexjob_recurring_jobs table.</summary>
+    internal const string V1CreateTables =
         """
         CREATE TABLE IF NOT EXISTS nexjob_jobs (
             id                    UUID         PRIMARY KEY,
@@ -45,29 +46,55 @@ internal static class SchemaSql
             WHERE completed_at IS NOT NULL;
 
         CREATE TABLE IF NOT EXISTS nexjob_recurring_jobs (
-            recurring_job_id  TEXT        PRIMARY KEY,
-            job_type          TEXT        NOT NULL,
-            input_type        TEXT        NOT NULL,
-            input_json        JSONB       NOT NULL,
-            cron              TEXT        NOT NULL,
-            time_zone_id      TEXT        NOT NULL DEFAULT 'UTC',
-            queue             TEXT        NOT NULL DEFAULT 'default',
-            next_execution          TIMESTAMPTZ,
-            last_execution          TIMESTAMPTZ,
-            last_execution_status   TEXT,
-            last_execution_error    TEXT,
-            concurrency_policy      TEXT        NOT NULL DEFAULT 'SkipIfRunning',
-            created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-            updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            recurring_job_id      TEXT        PRIMARY KEY,
+            job_type              TEXT        NOT NULL,
+            input_type            TEXT        NOT NULL,
+            input_json            JSONB       NOT NULL,
+            cron                  TEXT        NOT NULL,
+            time_zone_id          TEXT        NOT NULL DEFAULT 'UTC',
+            queue                 TEXT        NOT NULL DEFAULT 'default',
+            next_execution        TIMESTAMPTZ,
+            last_execution        TIMESTAMPTZ,
+            last_execution_status TEXT,
+            last_execution_error  TEXT,
+            concurrency_policy    TEXT        NOT NULL DEFAULT 'SkipIfRunning',
+            created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
         );
 
         CREATE INDEX IF NOT EXISTS idx_nexjob_recurring_next
             ON nexjob_recurring_jobs (next_execution);
+        """;
 
+    /// <summary>V2: Add cron_override, enabled, and deleted_by_user columns to nexjob_recurring_jobs.</summary>
+    internal const string V2AlterRecurring =
+        """
         ALTER TABLE nexjob_recurring_jobs ADD COLUMN IF NOT EXISTS cron_override TEXT NULL;
         ALTER TABLE nexjob_recurring_jobs ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE;
         ALTER TABLE nexjob_recurring_jobs ADD COLUMN IF NOT EXISTS deleted_by_user BOOLEAN NOT NULL DEFAULT FALSE;
-
-        ALTER TABLE nexjob_jobs ADD COLUMN IF NOT EXISTS execution_logs JSONB NULL;
         """;
+
+    /// <summary>V3: Add execution_logs and trace_parent columns to nexjob_jobs.</summary>
+    internal const string V3AddColumns =
+        """
+        ALTER TABLE nexjob_jobs ADD COLUMN IF NOT EXISTS execution_logs JSONB NULL;
+        ALTER TABLE nexjob_jobs ADD COLUMN IF NOT EXISTS trace_parent TEXT NULL;
+        """;
+
+    /// <summary>V4: Create nexjob_schema_version and nexjob_recurring_locks tables.</summary>
+    internal const string V4CreateVersionTable =
+        """
+        CREATE TABLE IF NOT EXISTS nexjob_schema_version (
+            version     INT         PRIMARY KEY,
+            applied_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            description TEXT        NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS nexjob_recurring_locks (
+            recurring_job_id TEXT        PRIMARY KEY,
+            expires_at       TIMESTAMPTZ NOT NULL
+        );
+        """;
+
+    /// <summary>Full initial schema — kept for backward compatibility. Prefer the versioned consts.</summary>
+    internal const string CreateTables = V1CreateTables;
 }

--- a/src/NexJob.Redis/RedisStorageProvider.cs
+++ b/src/NexJob.Redis/RedisStorageProvider.cs
@@ -604,6 +604,22 @@ public sealed class RedisStorageProvider : IStorageProvider
         await _db.HashSetAsync(JobKey(idStr), "executionLogs", json);
     }
 
+    /// <inheritdoc/>
+    public async Task<bool> TryAcquireRecurringJobLockAsync(
+        string recurringJobId, TimeSpan ttl, CancellationToken ct = default)
+    {
+        var key = (RedisKey)$"nexjob:lock:recurring:{recurringJobId}";
+        return await _db.StringSetAsync(key, "1", ttl, When.NotExists);
+    }
+
+    /// <inheritdoc/>
+    public async Task ReleaseRecurringJobLockAsync(
+        string recurringJobId, CancellationToken ct = default)
+    {
+        var key = (RedisKey)$"nexjob:lock:recurring:{recurringJobId}";
+        await _db.KeyDeleteAsync(key);
+    }
+
     // ── Private static helpers ────────────────────────────────────────────────
 
     private static string JobKey(string id) => $"nexjob:jobs:{id}";

--- a/src/NexJob.SqlServer/SchemaMigration.cs
+++ b/src/NexJob.SqlServer/SchemaMigration.cs
@@ -1,0 +1,3 @@
+namespace NexJob.SqlServer;
+
+internal sealed record SchemaMigration(int Version, string Description, string Sql);

--- a/src/NexJob.SqlServer/SchemaMigrator.cs
+++ b/src/NexJob.SqlServer/SchemaMigrator.cs
@@ -1,0 +1,90 @@
+using Dapper;
+using Microsoft.Data.SqlClient;
+
+namespace NexJob.SqlServer;
+
+/// <summary>
+/// Applies versioned DDL migrations to the SQL Server schema on startup.
+/// Uses <c>sp_getapplock</c> to prevent concurrent migration races when multiple
+/// instances start simultaneously.
+/// </summary>
+internal sealed class SchemaMigrator
+{
+    private static readonly IReadOnlyList<SchemaMigration> Migrations =
+    [
+        new(1, "initial schema", SqlServerSchemaSql.V1CreateTables),
+        new(2, "add recurring job config columns", SqlServerSchemaSql.V2AlterRecurring),
+        new(3, "add execution_logs and trace_parent columns", SqlServerSchemaSql.V3AddColumns),
+        new(4, "create schema_version and recurring_locks tables", SqlServerSchemaSql.V4CreateVersionTable),
+    ];
+
+    /// <summary>
+    /// Runs all pending migrations against <paramref name="connectionString"/>.
+    /// Acquires an application-level lock via <c>sp_getapplock</c>.
+    /// </summary>
+    /// <param name="connectionString">The SQL Server connection string.</param>
+    /// <param name="ct">Token to cancel the operation.</param>
+    public async Task MigrateAsync(string connectionString, CancellationToken ct = default)
+    {
+        await using var conn = new SqlConnection(connectionString);
+        await conn.OpenAsync(ct);
+        await using var tx = (SqlTransaction)await conn.BeginTransactionAsync(ct);
+
+        try
+        {
+            // Acquire exclusive app lock (scoped to transaction)
+            await conn.ExecuteAsync(
+                "EXEC sp_getapplock @Resource = 'nexjob_migration', @LockMode = 'Exclusive', @LockOwner = 'Transaction', @LockTimeout = 30000",
+                transaction: tx);
+
+            // Bootstrap version table
+            await conn.ExecuteAsync(
+                """
+                IF OBJECT_ID('nexjob_schema_version', 'U') IS NULL
+                CREATE TABLE nexjob_schema_version (
+                    version     INT           PRIMARY KEY,
+                    applied_at  DATETIME2     NOT NULL DEFAULT GETUTCDATE(),
+                    description NVARCHAR(500) NOT NULL
+                )
+                """,
+                transaction: tx);
+
+            var applied = (await conn.QueryAsync<int>(
+                "SELECT version FROM nexjob_schema_version", transaction: tx))
+                .ToHashSet();
+
+            foreach (var migration in Migrations)
+            {
+                if (applied.Contains(migration.Version))
+                {
+                    continue;
+                }
+
+                // Each migration SQL may contain multiple statements — split on GO
+                var statements = migration.Sql
+                    .Split(["\nGO\n", "\r\nGO\r\n"], StringSplitOptions.RemoveEmptyEntries);
+
+                foreach (var statement in statements)
+                {
+                    var trimmed = statement.Trim();
+                    if (trimmed.Length > 0)
+                    {
+                        await conn.ExecuteAsync(trimmed, transaction: tx);
+                    }
+                }
+
+                await conn.ExecuteAsync(
+                    "INSERT INTO nexjob_schema_version (version, description) VALUES (@v, @d)",
+                    new { v = migration.Version, d = migration.Description },
+                    transaction: tx);
+            }
+
+            await tx.CommitAsync(ct);
+        }
+        catch
+        {
+            await tx.RollbackAsync(ct);
+            throw;
+        }
+    }
+}

--- a/src/NexJob.SqlServer/SqlServerSchemaSql.cs
+++ b/src/NexJob.SqlServer/SqlServerSchemaSql.cs
@@ -2,7 +2,8 @@ namespace NexJob.SqlServer;
 
 internal static class SqlServerSchemaSql
 {
-    internal const string CreateTables =
+    /// <summary>V1: Initial schema — nexjob_jobs table (including execution_logs), indexes, nexjob_recurring_jobs table.</summary>
+    internal const string V1CreateTables =
         """
         IF OBJECT_ID('nexjob_jobs', 'U') IS NULL
         CREATE TABLE nexjob_jobs (
@@ -61,13 +62,47 @@ internal static class SqlServerSchemaSql
             last_execution_error  NVARCHAR(MAX)    NULL,
             concurrency_policy    NVARCHAR(50)     NOT NULL DEFAULT 'SkipIfRunning',
             created_at            DATETIMEOFFSET   NOT NULL DEFAULT SYSUTCDATETIME(),
-            updated_at            DATETIMEOFFSET   NOT NULL DEFAULT SYSUTCDATETIME(),
-            cron_override         NVARCHAR(200)    NULL,
-            enabled               BIT              NOT NULL DEFAULT 1,
-            deleted_by_user       BIT              NOT NULL DEFAULT 0
+            updated_at            DATETIMEOFFSET   NOT NULL DEFAULT SYSUTCDATETIME()
         );
 
         IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'idx_nexjob_recurring_next' AND object_id = OBJECT_ID('nexjob_recurring_jobs'))
         CREATE INDEX idx_nexjob_recurring_next ON nexjob_recurring_jobs (next_execution);
         """;
+
+    /// <summary>V2: Add cron_override, enabled, and deleted_by_user columns to nexjob_recurring_jobs.</summary>
+    internal const string V2AlterRecurring =
+        """
+        IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('nexjob_recurring_jobs') AND name = 'cron_override')
+            ALTER TABLE nexjob_recurring_jobs ADD cron_override NVARCHAR(200) NULL;
+        IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('nexjob_recurring_jobs') AND name = 'enabled')
+            ALTER TABLE nexjob_recurring_jobs ADD enabled BIT NOT NULL DEFAULT 1;
+        IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('nexjob_recurring_jobs') AND name = 'deleted_by_user')
+            ALTER TABLE nexjob_recurring_jobs ADD deleted_by_user BIT NOT NULL DEFAULT 0;
+        """;
+
+    /// <summary>V3: Add trace_parent column to nexjob_jobs.</summary>
+    internal const string V3AddColumns =
+        """
+        IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('nexjob_jobs') AND name = 'trace_parent')
+            ALTER TABLE nexjob_jobs ADD trace_parent NVARCHAR(500) NULL;
+        """;
+
+    /// <summary>V4: Create nexjob_schema_version and nexjob_recurring_locks tables.</summary>
+    internal const string V4CreateVersionTable =
+        """
+        IF OBJECT_ID('nexjob_schema_version', 'U') IS NULL
+        CREATE TABLE nexjob_schema_version (
+            version     INT           PRIMARY KEY,
+            applied_at  DATETIME2     NOT NULL DEFAULT GETUTCDATE(),
+            description NVARCHAR(500) NOT NULL
+        );
+        IF OBJECT_ID('nexjob_recurring_locks', 'U') IS NULL
+        CREATE TABLE nexjob_recurring_locks (
+            recurring_job_id NVARCHAR(500) PRIMARY KEY,
+            expires_at       DATETIME2     NOT NULL
+        );
+        """;
+
+    /// <summary>Full initial schema — kept for backward compatibility. Prefer the versioned consts.</summary>
+    internal const string CreateTables = V1CreateTables;
 }

--- a/src/NexJob.SqlServer/SqlServerStorageProvider.cs
+++ b/src/NexJob.SqlServer/SqlServerStorageProvider.cs
@@ -15,14 +15,15 @@ public sealed class SqlServerStorageProvider : IStorageProvider
     private readonly string _connectionString;
 
     /// <summary>
-    /// Initialises the provider and ensures the database schema exists.
-    /// Safe to call multiple times — all DDL statements use existence checks.
+    /// Initialises the provider and applies all pending schema migrations.
+    /// Acquires an application-level lock via <c>sp_getapplock</c> so only one instance migrates at a time.
     /// </summary>
     public SqlServerStorageProvider(string connectionString)
     {
         _connectionString = connectionString;
         Dapper.DefaultTypeMap.MatchNamesWithUnderscores = true;
-        EnsureSchema();
+        // Sync-over-async is acceptable here: runs once at startup, before any requests are served.
+        new SchemaMigrator().MigrateAsync(_connectionString).GetAwaiter().GetResult();
     }
 
     // ── EnqueueAsync ──────────────────────────────────────────────────────────
@@ -542,14 +543,43 @@ public sealed class SqlServerStorageProvider : IStorageProvider
             new { Id = jobId.Value, Logs = JsonSerializer.Serialize(logs) });
     }
 
+    /// <inheritdoc/>
+    public async Task<bool> TryAcquireRecurringJobLockAsync(
+        string recurringJobId, TimeSpan ttl, CancellationToken ct = default)
+    {
+        await using var conn = Open();
+        await conn.OpenAsync(ct);
+        await conn.ExecuteAsync(
+            "DELETE FROM nexjob_recurring_locks WHERE expires_at < SYSUTCDATETIME()");
+        try
+        {
+            await conn.ExecuteAsync(
+                """
+                INSERT INTO nexjob_recurring_locks (recurring_job_id, expires_at)
+                VALUES (@id, DATEADD(MILLISECOND, @ms, SYSUTCDATETIME()))
+                """,
+                new { id = recurringJobId, ms = (long)ttl.TotalMilliseconds });
+            return true;
+        }
+        catch (SqlException ex) when (ex.Number == 2627 || ex.Number == 2601)
+        {
+            // Primary key / unique constraint violation — lock already held
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task ReleaseRecurringJobLockAsync(
+        string recurringJobId, CancellationToken ct = default)
+    {
+        await using var conn = Open();
+        await conn.OpenAsync(ct);
+        await conn.ExecuteAsync(
+            "DELETE FROM nexjob_recurring_locks WHERE recurring_job_id = @id",
+            new { id = recurringJobId });
+    }
+
     // ── Schema ────────────────────────────────────────────────────────────────
 
     private SqlConnection Open() => new(_connectionString);
-
-    private void EnsureSchema()
-    {
-        using var conn = Open();
-        conn.Open();
-        conn.Execute(SqlServerSchemaSql.CreateTables);
-    }
 }

--- a/src/NexJob/Configuration/NexJobSettings.cs
+++ b/src/NexJob/Configuration/NexJobSettings.cs
@@ -35,6 +35,9 @@ public sealed class NexJobSettings
     /// <summary>Per-queue configuration, including optional execution windows.</summary>
     public List<QueueSettings> Queues { get; set; } = [];
 
+    /// <summary>Maximum seconds to wait for jobs during graceful shutdown. Defaults to <c>30</c>.</summary>
+    public int ShutdownTimeoutSeconds { get; set; } = 30;
+
     /// <summary>Dashboard-specific settings.</summary>
     public DashboardSettings Dashboard { get; set; } = new();
 }

--- a/src/NexJob/Internal/InMemoryStorageProvider.cs
+++ b/src/NexJob/Internal/InMemoryStorageProvider.cs
@@ -16,6 +16,7 @@ internal sealed class InMemoryStorageProvider : IStorageProvider
     private readonly ConcurrentDictionary<Guid, JobRecord> _jobs = new();
     private readonly ConcurrentDictionary<string, Guid> _idempotencyIndex = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, RecurringJobRecord> _recurringJobs = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _recurringLocks = new(StringComparer.Ordinal);
 
     // Indexed as: _queues[queueName][priorityIndex]
     // Priority indices: 0=Critical, 1=High, 2=Normal, 3=Low
@@ -488,6 +489,28 @@ internal sealed class InMemoryStorageProvider : IStorageProvider
             }
         }
 
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> TryAcquireRecurringJobLockAsync(
+        string recurringJobId, TimeSpan ttl, CancellationToken ct = default)
+    {
+        var expiry = DateTimeOffset.UtcNow.Add(ttl);
+        _recurringLocks.TryGetValue(recurringJobId, out var existing);
+        if (existing > DateTimeOffset.UtcNow)
+        {
+            return Task.FromResult(false);
+        }
+
+        _recurringLocks[recurringJobId] = expiry;
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc/>
+    public Task ReleaseRecurringJobLockAsync(string recurringJobId, CancellationToken ct = default)
+    {
+        _recurringLocks.TryRemove(recurringJobId, out _);
         return Task.CompletedTask;
     }
 

--- a/src/NexJob/Internal/JobDispatcherService.cs
+++ b/src/NexJob/Internal/JobDispatcherService.cs
@@ -29,6 +29,7 @@ internal sealed class JobDispatcherService : BackgroundService
     private readonly IRuntimeSettingsStore _runtimeStore;
     private readonly NexJobOptions _options;
     private readonly ILogger<JobDispatcherService> _logger;
+    private int _activeJobCount;
 
     /// <summary>
     /// Initializes a new <see cref="JobDispatcherService"/>.
@@ -47,6 +48,34 @@ internal sealed class JobDispatcherService : BackgroundService
         _runtimeStore = runtimeStore;
         _options = options;
         _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "NexJob shutting down. Waiting for {Count} active job(s) to complete (timeout: {Timeout}s)...",
+            _activeJobCount, _options.ShutdownTimeout.TotalSeconds);
+
+        var deadline = Task.Delay(_options.ShutdownTimeout, CancellationToken.None);
+
+        while (_activeJobCount > 0 && !deadline.IsCompleted)
+        {
+            await Task.Delay(250, CancellationToken.None);
+        }
+
+        if (_activeJobCount > 0)
+        {
+            _logger.LogWarning(
+                "Shutdown timeout reached. {Count} job(s) still active — they will be requeued by the orphan watcher.",
+                _activeJobCount);
+        }
+        else
+        {
+            _logger.LogInformation("All active jobs completed cleanly.");
+        }
+
+        await base.StopAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -108,16 +137,18 @@ internal sealed class JobDispatcherService : BackgroundService
                 continue;
             }
 
-            // Fire-and-forget: slot is released in the finally block inside the task
+            // Fire-and-forget: slot and active count are released in the finally block inside the task
+            Interlocked.Increment(ref _activeJobCount);
             _ = Task.Run(async () =>
             {
                 try
                 {
-                    await ExecuteJobAsync(job, stoppingToken);
+                    await ExecuteJobAsync(job);
                 }
                 finally
                 {
                     workerSlots.Release();
+                    Interlocked.Decrement(ref _activeJobCount);
                 }
             }, CancellationToken.None);
         }
@@ -153,12 +184,14 @@ internal sealed class JobDispatcherService : BackgroundService
 
     // ─── execution pipeline ──────────────────────────────────────────────────
 
-    private async Task ExecuteJobAsync(JobRecord job, CancellationToken stoppingToken)
+    private async Task ExecuteJobAsync(JobRecord job)
     {
         _logger.LogDebug("Executing job {JobId} ({JobType}), attempt {Attempt}/{Max}",
             job.Id, job.JobType, job.Attempts, job.MaxAttempts);
 
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+        // Do NOT link to stoppingToken — jobs should complete naturally on graceful shutdown.
+        // The orphan watcher handles jobs that are still running after ShutdownTimeout.
+        using var cts = new CancellationTokenSource();
         var heartbeatTask = RunHeartbeatAsync(job.Id, cts.Token);
 
         // Each job task has its own async context; the scope captures all log entries
@@ -195,13 +228,13 @@ internal sealed class JobDispatcherService : BackgroundService
             foreach (var attr in throttleAttrs)
             {
                 var sem = _throttleRegistry.GetOrCreate(attr.Resource, attr.MaxConcurrent);
-                await sem.WaitAsync(stoppingToken);
+                await sem.WaitAsync(cts.Token);
                 acquired.Add(sem);
             }
 
             try
             {
-                await invoker(jobInstance, input, stoppingToken);
+                await invoker(jobInstance, input, cts.Token);
             }
             finally
             {
@@ -228,11 +261,6 @@ internal sealed class JobDispatcherService : BackgroundService
 
             _logger.LogDebug("Job {JobId} completed successfully", job.Id);
         }
-        catch (OperationCanceledException ex) when (stoppingToken.IsCancellationRequested)
-        {
-            // Host is shutting down — do not retry; the orphan watcher will requeue
-            _logger.LogWarning(ex, "Job {JobId} was interrupted by host shutdown", job.Id);
-        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Job {JobId} failed on attempt {Attempt}", job.Id, job.Attempts);
@@ -246,16 +274,34 @@ internal sealed class JobDispatcherService : BackgroundService
                 { "exception.stacktrace", ex.StackTrace },
             }));
 
+            // Resolve [Retry] attribute — may be null if job type failed to load earlier
+            var retryAttrForCatch = job.JobType is not null
+                ? Type.GetType(job.JobType)?.GetCustomAttribute<RetryAttribute>(inherit: true)
+                : null;
+            var effectiveMaxAttemptsForCatch = retryAttrForCatch is not null
+                ? retryAttrForCatch.Attempts
+                : job.MaxAttempts;
+
             DateTimeOffset? retryAt = null;
 
-            if (job.Attempts < job.MaxAttempts)
+            if (job.Attempts < effectiveMaxAttemptsForCatch)
             {
-                retryAt = DateTimeOffset.UtcNow + _options.RetryDelayFactory(job.Attempts);
+                TimeSpan retryDelay;
+                if (retryAttrForCatch?.InitialDelay is not null)
+                {
+                    retryDelay = retryAttrForCatch.ComputeDelay(job.Attempts);
+                }
+                else
+                {
+                    retryDelay = _options.RetryDelayFactory(job.Attempts);
+                }
+
+                retryAt = DateTimeOffset.UtcNow + retryDelay;
             }
             else
             {
                 _logger.LogError(ex, "Job {JobId} exhausted all {Max} attempts — moving to dead-letter",
-                    job.Id, job.MaxAttempts);
+                    job.Id, effectiveMaxAttemptsForCatch);
             }
 
             await _storage.SetFailedAsync(job.Id, ex, retryAt, CancellationToken.None);

--- a/src/NexJob/NexJobOptions.cs
+++ b/src/NexJob/NexJobOptions.cs
@@ -39,6 +39,13 @@ public sealed class NexJobOptions
     public TimeSpan HeartbeatTimeout { get; set; } = TimeSpan.FromMinutes(5);
 
     /// <summary>
+    /// Maximum time to wait for active jobs to complete during graceful shutdown.
+    /// Jobs still running after this timeout are left for the orphan watcher to requeue.
+    /// Defaults to 30 seconds.
+    /// </summary>
+    public TimeSpan ShutdownTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     /// Ordered list of queue names that workers on this host will poll.
     /// Queues are drained in the order specified. Defaults to <c>["default"]</c>.
     /// </summary>
@@ -81,6 +88,11 @@ public sealed class NexJobOptions
         if (s.Queues.Count > 0)
         {
             Queues = s.Queues.Select(q => q.Name).ToArray();
+        }
+
+        if (s.ShutdownTimeoutSeconds > 0)
+        {
+            ShutdownTimeout = TimeSpan.FromSeconds(s.ShutdownTimeoutSeconds);
         }
     }
 }

--- a/src/NexJob/RetryAttribute.cs
+++ b/src/NexJob/RetryAttribute.cs
@@ -1,0 +1,83 @@
+using System.Globalization;
+
+namespace NexJob;
+
+/// <summary>
+/// Configures the retry policy for a specific job type, overriding the global defaults
+/// set on <see cref="NexJobOptions"/>.
+/// </summary>
+/// <example>
+/// <code>
+/// [Retry(5, InitialDelay = "00:00:30", Multiplier = 2.0, MaxDelay = "01:00:00")]
+/// public class PaymentJob : IJob&lt;PaymentInput&gt; { ... }
+///
+/// [Retry(0)]  // dead-letter immediately on failure, no retries
+/// public class WebhookJob : IJob&lt;WebhookInput&gt; { ... }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class RetryAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new <see cref="RetryAttribute"/>.
+    /// </summary>
+    /// <param name="attempts">Maximum number of retry attempts. Must be non-negative.</param>
+    public RetryAttribute(int attempts)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(attempts);
+        Attempts = attempts;
+    }
+
+    /// <summary>
+    /// Maximum number of retry attempts. <c>0</c> means dead-letter immediately on first failure.
+    /// </summary>
+    public int Attempts { get; }
+
+    /// <summary>
+    /// Initial delay before the first retry, as a <see cref="TimeSpan"/> string
+    /// (e.g. <c>"00:00:30"</c> for 30 seconds).
+    /// When <see langword="null"/>, the global <see cref="NexJobOptions.RetryDelayFactory"/> is used.
+    /// </summary>
+    public string? InitialDelay { get; init; }
+
+    /// <summary>
+    /// Multiplier applied to the delay on each subsequent retry.
+    /// For example, <c>2.0</c> doubles the delay on each attempt. Default: <c>2.0</c>.
+    /// </summary>
+    public double Multiplier { get; init; } = 2.0;
+
+    /// <summary>
+    /// Maximum delay cap as a <see cref="TimeSpan"/> string (e.g. <c>"01:00:00"</c> for 1 hour).
+    /// When <see langword="null"/>, no cap is applied.
+    /// </summary>
+    public string? MaxDelay { get; init; }
+
+    /// <summary>
+    /// Computes the retry delay for a given attempt number using this attribute's configuration.
+    /// </summary>
+    /// <param name="attempt">1-based attempt number.</param>
+    /// <returns>The delay before the next retry attempt.</returns>
+    internal TimeSpan ComputeDelay(int attempt)
+    {
+        if (InitialDelay is null)
+        {
+            return TimeSpan.Zero; // caller falls back to global factory
+        }
+
+        var initial = TimeSpan.Parse(InitialDelay, CultureInfo.InvariantCulture);
+        var delay = TimeSpan.FromTicks((long)(initial.Ticks * Math.Pow(Multiplier, attempt - 1)));
+
+        if (MaxDelay is not null)
+        {
+            var max = TimeSpan.Parse(MaxDelay, CultureInfo.InvariantCulture);
+            if (delay > max)
+            {
+                delay = max;
+            }
+        }
+
+        // Add ±10% jitter
+        var jitterFactor = 1.0 + (0.1 * ((Random.Shared.NextDouble() * 2.0) - 1.0));
+        return TimeSpan.FromTicks((long)(delay.Ticks * jitterFactor));
+    }
+}

--- a/src/NexJob/Storage/IStorageProvider.cs
+++ b/src/NexJob/Storage/IStorageProvider.cs
@@ -214,4 +214,20 @@ public interface IStorageProvider
     /// Returns per-queue metrics (enqueued + processing counts) for all active queues.
     /// </summary>
     Task<IReadOnlyList<QueueMetrics>> GetQueueMetricsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Attempts to acquire an exclusive lock for scheduling a recurring job.
+    /// Returns <see langword="true"/> if the lock was acquired (caller should enqueue the job).
+    /// Returns <see langword="false"/> if another instance already holds the lock.
+    /// The lock expires automatically after <paramref name="ttl"/>.
+    /// </summary>
+    /// <param name="recurringJobId">The identifier of the recurring job to lock.</param>
+    /// <param name="ttl">How long the lock remains valid before expiring automatically.</param>
+    /// <param name="ct">Token to cancel the operation.</param>
+    Task<bool> TryAcquireRecurringJobLockAsync(string recurringJobId, TimeSpan ttl, CancellationToken ct = default);
+
+    /// <summary>Releases the recurring job scheduling lock.</summary>
+    /// <param name="recurringJobId">The identifier of the recurring job whose lock should be released.</param>
+    /// <param name="ct">Token to cancel the operation.</param>
+    Task ReleaseRecurringJobLockAsync(string recurringJobId, CancellationToken ct = default);
 }


### PR DESCRIPTION
## Summary

- **Graceful shutdown** — `JobDispatcherService.StopAsync` now waits up to `ShutdownTimeout` (default 30s, configurable via `NexJobSettings.ShutdownTimeoutSeconds`) for active jobs to finish before the host stops. Jobs are no longer cancelled by the stopping token; the orphan watcher handles any stragglers that exceed the timeout.
- **`[Retry]` attribute** — new `RetryAttribute(int attempts)` with optional `InitialDelay`, `Multiplier`, and `MaxDelay` properties. Decorating a job class overrides the global `NexJobOptions.RetryDelayFactory` for that type. `[Retry(0)]` dead-letters immediately on first failure.
- **Versioned schema migrations** — `EnsureSchema()` replaced with a proper `SchemaMigrator` for Postgres (`pg_advisory_lock`) and SQL Server (`sp_getapplock`). Both track applied migrations in `nexjob_schema_version` (V1–V4). Safe for concurrent multi-instance startups.
- **Distributed recurring-job locks** — `IStorageProvider` gains `TryAcquireRecurringJobLockAsync` / `ReleaseRecurringJobLockAsync`. Implemented in all five providers: InMemory (ConcurrentDictionary + expiry), Postgres (INSERT … ON CONFLICT DO NOTHING), SQL Server (INSERT + PK violation catch), MongoDB (InsertOne + DuplicateKey catch + TTL index), Redis (SET NX + TTL).

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings (all StyleCop/SonarSource rules pass)
- [x] `dotnet test tests/NexJob.Tests/` — 104/104 passed
- [ ] Integration tests (Postgres + MongoDB via Testcontainers) — run locally with Docker
- [ ] Verify graceful shutdown log output in `NexJob.Sample.WebApi`
- [ ] Verify `[Retry(0)]` dead-letters immediately; `[Retry(3, InitialDelay="00:00:05", Multiplier=2.0)]` retries with correct delays

🤖 Generated with [Claude Code](https://claude.com/claude-code)