### PR TITLE
fix(benchmarks): restore fixes lost in squash merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ TestResults/
 
 # BenchmarkDotNet
 BenchmarkDotNet.Artifacts/
-benchmarks/results/

--- a/benchmarks/NexJob.Benchmarks/HangfireNoOpJob.cs
+++ b/benchmarks/NexJob.Benchmarks/HangfireNoOpJob.cs
@@ -3,12 +3,11 @@ namespace NexJob.Benchmarks;
 /// <summary>Hangfire no-op job stub for throughput benchmarks.</summary>
 public static class HangfireNoOpJob
 {
-    /// <summary>Increments the completion counter and signals when all jobs have finished.</summary>
-    public static void Execute(ref int completed, TaskCompletionSource<bool> tcs, int target)
-    {
-        if (Interlocked.Increment(ref completed) >= target)
-        {
-            tcs.TrySetResult(true);
-        }
-    }
+    private static Action? _onExecuted;
+
+    /// <summary>Sets the callback invoked after each job execution.</summary>
+    public static void SetCompletionCallback(Action? callback) => _onExecuted = callback;
+
+    /// <summary>No-op execute method enqueued by Hangfire.</summary>
+    public static void Execute() => _onExecuted?.Invoke();
 }

--- a/benchmarks/NexJob.Benchmarks/ThroughputBenchmark.cs
+++ b/benchmarks/NexJob.Benchmarks/ThroughputBenchmark.cs
@@ -92,14 +92,23 @@ public class ThroughputBenchmark
     [Benchmark]
     public void Hangfire_FireAndForget()
     {
-        var completed = 0;
         var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completed = 0;
+
+        HangfireNoOpJob.SetCompletionCallback(() =>
+        {
+            if (Interlocked.Increment(ref completed) >= JobCount)
+            {
+                tcs.TrySetResult(true);
+            }
+        });
 
         for (var i = 0; i < JobCount; i++)
         {
-            _hangfireClient.Enqueue(() => HangfireNoOpJob.Execute(ref completed, tcs, JobCount));
+            _hangfireClient.Enqueue(() => HangfireNoOpJob.Execute());
         }
 
         tcs.Task.Wait(TimeSpan.FromSeconds(30));
+        HangfireNoOpJob.SetCompletionCallback(null);
     }
 }

--- a/benchmarks/results/README.md
+++ b/benchmarks/results/README.md
@@ -1,0 +1,33 @@
+# NexJob Benchmark Results
+
+BenchmarkDotNet v0.14.0, Ubuntu 24.04.4 LTS (Noble Numbat)
+Intel Xeon CPU E5-2667 v4 3.20GHz, 1 CPU, 16 logical and 8 physical cores
+.NET SDK 8.0.125 · .NET 8.0.25 (8.0.2526.11203), X64 RyuJIT AVX2
+Run: March 2026
+
+---
+
+## EnqueueLatencyBenchmark
+
+Single job enqueue, in-memory storage.
+
+| Method                 | Job      | Mean      | Error     | StdDev    | Ratio | Gen0   | Gen1   | Allocated | Alloc Ratio |
+|----------------------- |--------- |----------:|----------:|----------:|------:|-------:|-------:|----------:|------------:|
+| NexJob_SingleEnqueue   | .NET 8.0 | 12.713 μs | 0.9973 μs | 2.8453 μs |  1.08 | 0.0610 | 0.0305 |   2.77 KB |        1.00 |
+| Hangfire_SingleEnqueue | .NET 8.0 | 35.817 μs | 1.3414 μs | 3.9552 μs |  3.03 | 0.8850 | 0.2136 |  11.31 KB |        4.09 |
+|                        |          |           |           |           |       |        |        |           |             |
+| NexJob_SingleEnqueue   | ShortRun |  9.283 μs | 6.9796 μs | 0.3826 μs |  1.00 | 0.0610 |      - |   1.67 KB |        1.00 |
+| Hangfire_SingleEnqueue | ShortRun | 26.629 μs | 6.5590 μs | 0.3595 μs |  2.87 | 0.8545 | 0.2136 |   11.2 KB |        6.70 |
+
+**ShortRun summary:** NexJob is **2.87x faster** and uses **85% less memory** per enqueue.
+
+---
+
+## ThroughputBenchmark
+
+> Note: The Hangfire throughput benchmark was not included in published results because
+> Hangfire has no built-in mechanism to await job completion from the enqueue side.
+> The benchmark measured different things (NexJob waited for all 500 jobs to finish;
+> Hangfire measured enqueue-only), making the comparison invalid.
+> Run `dotnet run -c Release --project benchmarks/NexJob.Benchmarks -- --filter '*Throughput*'`
+> to measure locally.


### PR DESCRIPTION
## Summary

The squash merge of PR #17 picked up the first commit state, before these fixes were applied:

- `HangfireNoOpJob`: restore static callback pattern — Hangfire cannot serialize `ref` parameters in job expressions
- `ThroughputBenchmark`: restore corrected `Hangfire_FireAndForget` using `SetCompletionCallback`
- `.gitignore`: remove `benchmarks/results/` exclusion (results are intentionally versioned)
- `benchmarks/results/README.md`: add raw BenchmarkDotNet output with real numbers

## Test plan

- [ ] `dotnet build --configuration Release` → 0 errors, 0 warnings
- [ ] `dotnet format --verify-no-changes` → clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)