### PR TITLE
fix(pack): add README.md to SqlServer, Redis, Oracle packages

### DIFF
--- a/src/NexJob.Oracle/NexJob.Oracle.csproj
+++ b/src/NexJob.Oracle/NexJob.Oracle.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NexJob\NexJob.csproj" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.7.0" />
   </ItemGroup>

--- a/src/NexJob.Redis/NexJob.Redis.csproj
+++ b/src/NexJob.Redis/NexJob.Redis.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NexJob\NexJob.csproj" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
   </ItemGroup>

--- a/src/NexJob.SqlServer/NexJob.SqlServer.csproj
+++ b/src/NexJob.SqlServer/NexJob.SqlServer.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NexJob\NexJob.csproj" />
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />


### PR DESCRIPTION
## Summary

NU5039 failure in publish CI: `PackageReadmeFile` is set globally in `Directory.Build.props` but `NexJob.SqlServer`, `NexJob.Redis`, and `NexJob.Oracle` were missing the `<None Include="README.md" Pack="true" PackagePath="\"/>` item.

## Test plan

- [ ] `dotnet pack src/NexJob.SqlServer/...` → success
- [ ] `dotnet pack src/NexJob.Redis/...` → success  
- [ ] `dotnet pack src/NexJob.Oracle/...` → success
- [ ] CI pack step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)