### PR TITLE
fix(tests): reduce WakeUpChannel timing threshold to fix flaky CI test

### DIFF
--- a/tests/NexJob.Tests/WakeUpChannelTests.cs
+++ b/tests/NexJob.Tests/WakeUpChannelTests.cs
@@ -37,7 +37,7 @@ public sealed class WakeUpChannelTests
         sw.Stop();
 
         received.Should().BeFalse();
-        sw.Elapsed.Should().BeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(50));
+        sw.Elapsed.Should().BeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(45));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Reduces the elapsed time threshold in `WakeUpChannelTests.cs` from 50ms to 45ms. 
CI runners occasionally complete the 50ms timeout in 49ms due to timing precision, causing flaky failures.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] New storage provider
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Checklist
- [x] `dotnet build` passes with **0 warnings**
- [x] `dotnet test` passes — no regressions
- [x] New behaviour is covered by tests
- [x] Public API has XML documentation (`///`)
- [x] Commit messages follow Conventional Commits