### PR TITLE
release: v0.6.0

### DIFF
--- a/tests/NexJob.Tests/WakeUpChannelTests.cs
+++ b/tests/NexJob.Tests/WakeUpChannelTests.cs
@@ -37,7 +37,7 @@ public sealed class WakeUpChannelTests
         sw.Stop();
 
         received.Should().BeFalse();
-        sw.Elapsed.Should().BeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(50));
+        sw.Elapsed.Should().BeGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(45));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Release v0.6.0 — fix flaky WakeUpChannel timing test blocking CI.

## Type of change
- [x] Bug fix

## Checklist
- [x] `dotnet build` passes with **0 warnings**
- [x] `dotnet test` passes — no regressions
- [x] Commit messages follow Conventional Commits

## Related issues
N/A