### PR TITLE
chore(analyzers): add xunit.analyzers to test projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -57,4 +57,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+  <!-- xUnit analyzers: test-specific diagnostics (async void tests, wrong assertions, etc.) -->
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
+    <PackageReference Include="xunit.analyzers" Version="1.16.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Add `xunit.analyzers` scoped to test projects via `Directory.Build.props` condition, enabling test-specific diagnostics for async void tests, wrong assertion patterns, and incorrect fixture usage. Version set to 1.16.0 (instead of work order's 1.11.0) to satisfy the transitive dependency requirement of xunit 2.9.2.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] New storage provider
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist
- [x] `dotnet build` passes with **0 warnings**
- [x] `dotnet test` passes — no regressions (220 unit tests green; distributed reliability test failures are pre-existing and unrelated to this change)
- [ ] New behaviour is covered by tests
- [ ] Public API has XML documentation (`///`)
- [x] Commit messages follow Conventional Commits