### PR TITLE
fix(storage): explicit rollback on early returns in EnqueueAsync

### DIFF
--- a/src/NexJob.Postgres/PostgresStorageProvider.cs
+++ b/src/NexJob.Postgres/PostgresStorageProvider.cs
@@ -62,6 +62,7 @@ public sealed class PostgresStorageProvider : IStorageProvider
 
                 if (IsActiveState(existingStatus))
                 {
+                    await tx.RollbackAsync(cancellationToken).ConfigureAwait(false);
                     return new EnqueueResult(existingId, WasRejected: false);
                 }
 
@@ -71,6 +72,7 @@ public sealed class PostgresStorageProvider : IStorageProvider
 
                 if (reject)
                 {
+                    await tx.RollbackAsync(cancellationToken).ConfigureAwait(false);
                     return new EnqueueResult(existingId, WasRejected: true);
                 }
             }

--- a/src/NexJob.SqlServer/SqlServerStorageProvider.cs
+++ b/src/NexJob.SqlServer/SqlServerStorageProvider.cs
@@ -57,6 +57,7 @@ public sealed class SqlServerStorageProvider : IStorageProvider
 
                 if (IsActiveState(existingStatus))
                 {
+                    await tx.RollbackAsync(cancellationToken).ConfigureAwait(false);
                     return new EnqueueResult(existingId, WasRejected: false);
                 }
 
@@ -66,6 +67,7 @@ public sealed class SqlServerStorageProvider : IStorageProvider
 
                 if (reject)
                 {
+                    await tx.RollbackAsync(cancellationToken).ConfigureAwait(false);
                     return new EnqueueResult(existingId, WasRejected: true);
                 }
             }


### PR DESCRIPTION
## Summary
Adds explicit `RollbackAsync` calls before early returns in `EnqueueAsync` for PostgreSQL and SQL Server providers. When an existing job with the same idempotency key is found, the method was returning without explicitly rolling back the open transaction — relying on `await using` dispose, which does not guarantee automatic rollback across all driver versions.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] New storage provider
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist
- [x] `dotnet build` passes with **0 warnings**
- [x] `dotnet test` passes — no regressions (228 tests)
- [ ] New behaviour is covered by tests
- [ ] Public API has XML documentation (`///`)
- [x] Commit messages follow Conventional Commits

## Related issues
<!-- Closes #123 -->