### PR TITLE
ci: fix release PAT and remove CI double-trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [develop]
   pull_request:
     branches: [develop, main]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Extract version from Directory.Build.props
         id: version
@@ -24,13 +25,19 @@ jobs:
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
 
       - name: Check tag does not already exist
+        id: tag_check
         run: |
           if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
             echo "Tag ${{ steps.version.outputs.tag }} already exists — skipping release."
-            exit 0
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Create and push tag
+        if: steps.tag_check.outputs.skip == 'false'
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -38,6 +45,7 @@ jobs:
           git push origin "${{ steps.version.outputs.tag }}"
 
       - name: Create GitHub Release
+        if: steps.tag_check.outputs.skip == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
Fixes two independent CI/CD workflow issues: (1) release.yml now uses a PAT for git push so that the tag creation triggers publish.yml for NuGet publishing, and (2) ci.yml push trigger removed to prevent double-trigger on PRs against develop.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] New storage provider
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist
- [x] No code changes — only GitHub Actions workflow files
- [x] Changes follow minimal safe change principle

## Related issues
<!-- Closes #123 -->

---

**⚠️ Prerequisite before merge:** Create the `RELEASE_PAT` secret in GitHub:
`Settings → Secrets and variables → Actions → New repository secret`
- **Name:** `RELEASE_PAT`
- **Value:** PAT with scope `repo` (Contents: read & write)