### PR TITLE
fix(release): make workflow idempotent for re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,24 +24,36 @@ jobs:
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
 
       - name: Check tag does not already exist
+        id: tag_check
         run: |
           if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "Tag ${{ steps.version.outputs.tag }} already exists — skipping release."
-            exit 0
+            echo "Tag ${{ steps.version.outputs.tag }} already exists — skipping tag creation."
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Create and push tag
+        if: steps.tag_check.outputs.skip == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ steps.version.outputs.tag }}" \
-            --title "${{ steps.version.outputs.tag }}" \
-            --generate-notes \
-            --prerelease=${{ contains(steps.version.outputs.tag, '-') }}
+          if gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Release ${{ steps.version.outputs.tag }} already exists — updating notes."
+            gh release edit "${{ steps.version.outputs.tag }}" \
+              --title "${{ steps.version.outputs.tag }}" \
+              --generate-notes \
+              --prerelease=${{ contains(steps.version.outputs.tag, '-') }}
+          else
+            gh release create "${{ steps.version.outputs.tag }}" \
+              --title "${{ steps.version.outputs.tag }}" \
+              --generate-notes \
+              --prerelease=${{ contains(steps.version.outputs.tag, '-') }}
+          fi


### PR DESCRIPTION
## Summary
Fix release workflow to handle re-runs gracefully when tag/release already exists.

## Changes
- Tag creation now skips if tag already exists (uses `skip` output)
- Release step now updates existing release instead of failing
- Allows safe re-runs without manual tag/release cleanup

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] New storage provider
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist
- [x] Workflow fix tested locally
- [x] No other files modified

## Related issues
Fixes failed release run for v0.7.0 where tag already existed.