### PR TITLE
feat(scheduler): add ContinueWithAsync no-input overload and document Throttle scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`ContinueWithAsync<TJob>`** — new no-input overload for chaining `IJob` continuations after a parent job completes.
+- **`ThrottleAttribute` documentation** — clarified that concurrency limits are enforced per worker process (local), not cluster-wide.
+
 ### Changed
 
 ### Fixed

--- a/src/NexJob/IScheduler.cs
+++ b/src/NexJob/IScheduler.cs
@@ -249,6 +249,20 @@ public interface IScheduler
         where TJob : IJob<TInput>;
 
     /// <summary>
+    /// Schedules a no-input job to execute immediately after the specified parent job succeeds.
+    /// </summary>
+    /// <typeparam name="TJob">The <see cref="IJob"/> implementation to execute.</typeparam>
+    /// <param name="parentJobId">The identifier of the job that must complete before this one runs.</param>
+    /// <param name="queue">Target queue name. Uses the default queue when <see langword="null"/>.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>The identifier of the continuation job.</returns>
+    Task<JobId> ContinueWithAsync<TJob>(
+        JobId parentJobId,
+        string? queue = null,
+        CancellationToken cancellationToken = default)
+        where TJob : IJob;
+
+    /// <summary>
     /// Removes a recurring job definition. Any already-enqueued instances are not affected.
     /// </summary>
     /// <param name="recurringJobId">The identifier of the recurring job to remove.</param>

--- a/src/NexJob/Internal/DefaultScheduler.cs
+++ b/src/NexJob/Internal/DefaultScheduler.cs
@@ -338,6 +338,41 @@ internal sealed class DefaultScheduler : IScheduler
     }
 
     /// <inheritdoc/>
+    public async Task<JobId> ContinueWithAsync<TJob>(
+        JobId parentJobId,
+        string? queue = null,
+        CancellationToken cancellationToken = default)
+        where TJob : IJob
+    {
+        var traceParent = Activity.Current?.Id;
+
+        var job = new JobRecord
+        {
+            Id = JobId.New(),
+            JobType = typeof(TJob).AssemblyQualifiedName!,
+            InputType = typeof(NoInput).AssemblyQualifiedName!,
+            InputJson = JsonSerializer.Serialize(NoInput.Instance),
+            Queue = queue ?? "default",
+            Priority = JobPriority.Normal,
+            Status = JobStatus.AwaitingContinuation,
+            ParentJobId = parentJobId,
+            CreatedAt = DateTimeOffset.UtcNow,
+            MaxAttempts = _options.MaxAttempts,
+            TraceParent = traceParent,
+            Tags = [],
+        };
+
+        using var activity = NexJobActivitySource.StartEnqueue(typeof(TJob).FullName ?? typeof(TJob).Name, job.Queue);
+        var jobId = await _storage.EnqueueAsync(job, DuplicatePolicy.AllowAfterFailed, cancellationToken).ConfigureAwait(false);
+
+        activity?.SetTag("nexjob.job_id", jobId.JobId.Value.ToString());
+        activity?.SetTag("nexjob.parent_job_id", parentJobId.Value.ToString());
+        NexJobMetrics.JobsEnqueued.Add(1, new TagList { { "nexjob.job_type", typeof(TJob).Name }, { "nexjob.queue", job.Queue }, { "nexjob.continuation", "true" } });
+
+        return jobId.JobId;
+    }
+
+    /// <inheritdoc/>
     public Task RemoveRecurringAsync(string recurringJobId, CancellationToken cancellationToken = default) =>
         _storage.DeleteRecurringJobAsync(recurringJobId, cancellationToken);
 

--- a/src/NexJob/ThrottleAttribute.cs
+++ b/src/NexJob/ThrottleAttribute.cs
@@ -6,8 +6,15 @@ namespace NexJob;
 /// resource exhaustion on shared external systems.
 /// </summary>
 /// <remarks>
+/// <para>
+/// The concurrency limit is enforced <strong>per worker process</strong> using an in-memory
+/// semaphore. In a multi-node deployment each node maintains its own independent limit —
+/// the effective cluster-wide concurrency is <c>maxConcurrent × nodeCount</c>.
+/// </para>
+/// <para>
 /// Multiple <see cref="ThrottleAttribute"/> instances may be applied to the same job
 /// to throttle against several independent resources simultaneously.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code>

--- a/tests/NexJob.Tests/DefaultSchedulerTests.cs
+++ b/tests/NexJob.Tests/DefaultSchedulerTests.cs
@@ -179,6 +179,19 @@ public sealed class DefaultSchedulerTests
         cont.Should().NotBeNull("continuation should now be runnable");
     }
 
+    [Fact]
+    public async Task ContinueWithAsync_NoInput_JobStaysAwaitingUntilParentCompletes()
+    {
+        var parentId = await _sut.EnqueueAsync<StubNoInputJob>();
+        await _sut.ContinueWithAsync<StubNoInputJob>(parentId);
+
+        var jobs = await _storage.GetJobsAsync(new JobFilter(), 1, 10);
+        var child = jobs.Items.FirstOrDefault(j => j.ParentJobId == parentId);
+
+        child.Should().NotBeNull();
+        child!.Status.Should().Be(JobStatus.AwaitingContinuation);
+    }
+
     // ─── RemoveRecurringAsync ─────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary
Adds a no-input overload for `ContinueWithAsync<TJob>` to achieve API symmetry with `EnqueueAsync` and `ScheduleAsync`, and updates `ThrottleAttribute` documentation to clarify that concurrency limits are enforced per worker process (local), not cluster-wide.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] New storage provider
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist
- [x] `dotnet build` passes with **0 warnings**
- [x] `dotnet test` passes — no regressions
- [x] New behaviour is covered by tests
- [x] Public API has XML documentation (`///`)
- [x] Commit messages follow Conventional Commits

## Related issues
<!-- Closes #123 -->