### PR TITLE
feat(storage): persistent IRuntimeSettingsStore across all providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **`IDashboardAuthorizationHandler`** — pluggable authorization interface for the NexJob dashboard. Implement and register in DI to control access with any strategy: role-based, claims, API key, IP whitelist, or custom logic. No handler registered = open access (suitable for development and internal networks).
 - **`ContinueWithAsync<TJob>`** — new no-input overload for chaining `IJob` continuations after a parent job completes.
 - **`ThrottleAttribute` documentation** — clarified that concurrency limits are enforced per worker process (local), not cluster-wide.
+- **Persistent `IRuntimeSettingsStore`** — all four storage providers (PostgreSQL, SQL Server, Redis, MongoDB) now implement `IRuntimeSettingsStore`, persisting runtime configuration (worker count, polling interval, paused queues, recurring jobs paused) across application restarts. Dashboard overrides no longer require reapplication after each deploy. The in-memory store remains as fallback when no persistent provider is configured.
 
 ### Changed
 

--- a/src/NexJob.MongoDB/MongoNexJobExtensions.cs
+++ b/src/NexJob.MongoDB/MongoNexJobExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
+using NexJob.Configuration;
 using NexJob.Storage;
 
 namespace NexJob.MongoDB;
@@ -36,6 +37,7 @@ public static class MongoNexJobExtensions
         services.AddSingleton<IMongoDatabase>(sp =>
             sp.GetRequiredService<IMongoClient>().GetDatabase(databaseName));
         services.AddSingleton<IStorageProvider, MongoStorageProvider>();
+        services.AddSingleton<IRuntimeSettingsStore, MongoRuntimeSettingsStore>();
 
         return services;
     }
@@ -50,6 +52,7 @@ public static class MongoNexJobExtensions
         RegisterSerializers();
         services.AddSingleton(database);
         services.AddSingleton<IStorageProvider, MongoStorageProvider>();
+        services.AddSingleton<IRuntimeSettingsStore, MongoRuntimeSettingsStore>();
         return services;
     }
 

--- a/src/NexJob.MongoDB/MongoRuntimeSettingsStore.cs
+++ b/src/NexJob.MongoDB/MongoRuntimeSettingsStore.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using NexJob.Configuration;
+
+namespace NexJob.MongoDB;
+
+/// <summary>
+/// MongoDB-backed implementation of <see cref="IRuntimeSettingsStore"/>.
+/// Persists runtime configuration as a JSON document in the <c>nexjob_settings</c>
+/// collection so that dashboard overrides survive application restarts.
+/// </summary>
+public sealed class MongoRuntimeSettingsStore : IRuntimeSettingsStore
+{
+    private const string SettingsId = "runtime_settings";
+    private readonly IMongoCollection<BsonDocument> _collection;
+
+    /// <summary>Initializes a new <see cref="MongoRuntimeSettingsStore"/>.</summary>
+    public MongoRuntimeSettingsStore(IMongoDatabase database)
+    {
+        _collection = database.GetCollection<BsonDocument>("nexjob_settings");
+    }
+
+    /// <inheritdoc/>
+    public async Task<RuntimeSettings> GetAsync(CancellationToken ct = default)
+    {
+        var doc = await _collection
+            .Find(Builders<BsonDocument>.Filter.Eq("_id", SettingsId))
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+        if (doc is null)
+        {
+            return new RuntimeSettings();
+        }
+
+        var json = doc["value"].AsString;
+        return JsonSerializer.Deserialize<RuntimeSettings>(json) ?? new RuntimeSettings();
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveAsync(RuntimeSettings settings, CancellationToken ct = default)
+    {
+        settings.UpdatedAt = DateTimeOffset.UtcNow;
+        var json = JsonSerializer.Serialize(settings);
+
+        var filter = Builders<BsonDocument>.Filter.Eq("_id", SettingsId);
+        var update = Builders<BsonDocument>.Update
+            .Set("value", json)
+            .Set("updated_at", settings.UpdatedAt);
+
+        await _collection.UpdateOneAsync(
+            filter,
+            update,
+            new UpdateOptions { IsUpsert = true, },
+            ct).ConfigureAwait(false);
+    }
+}

--- a/src/NexJob.Postgres/NexJobPostgresExtensions.cs
+++ b/src/NexJob.Postgres/NexJobPostgresExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using NexJob.Configuration;
 using NexJob.Storage;
 
 namespace NexJob.Postgres;
@@ -19,6 +20,7 @@ public static class NexJobPostgresExtensions
         string connectionString)
     {
         services.AddSingleton<IStorageProvider>(_ => new PostgresStorageProvider(connectionString));
+        services.AddSingleton<IRuntimeSettingsStore>(_ => new PostgresRuntimeSettingsStore(connectionString));
         return services;
     }
 }

--- a/src/NexJob.Postgres/PostgresRuntimeSettingsStore.cs
+++ b/src/NexJob.Postgres/PostgresRuntimeSettingsStore.cs
@@ -1,0 +1,59 @@
+#pragma warning disable MA0004
+using System.Text.Json;
+using Dapper;
+using NexJob.Configuration;
+using Npgsql;
+
+namespace NexJob.Postgres;
+
+/// <summary>
+/// PostgreSQL-backed implementation of <see cref="IRuntimeSettingsStore"/>.
+/// Persists runtime configuration in the <c>nexjob_settings</c> table so that
+/// dashboard overrides survive application restarts.
+/// </summary>
+public sealed class PostgresRuntimeSettingsStore : IRuntimeSettingsStore
+{
+    private const string SettingsKey = "runtime_settings";
+    private readonly string _connectionString;
+
+    /// <summary>Initializes a new <see cref="PostgresRuntimeSettingsStore"/>.</summary>
+    public PostgresRuntimeSettingsStore(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    /// <inheritdoc/>
+    public async Task<RuntimeSettings> GetAsync(CancellationToken ct = default)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+
+        var json = await conn.ExecuteScalarAsync<string?>(
+            "SELECT value FROM nexjob_settings WHERE key = @key",
+            new { key = SettingsKey, }).ConfigureAwait(false);
+
+        return json is null
+            ? new RuntimeSettings()
+            : JsonSerializer.Deserialize<RuntimeSettings>(json) ?? new RuntimeSettings();
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveAsync(RuntimeSettings settings, CancellationToken ct = default)
+    {
+        settings.UpdatedAt = DateTimeOffset.UtcNow;
+        var json = JsonSerializer.Serialize(settings);
+
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+
+        await conn.ExecuteAsync(
+            """
+            INSERT INTO nexjob_settings (key, value, updated_at)
+            VALUES (@key, @value, NOW())
+            ON CONFLICT (key) DO UPDATE
+                SET value = EXCLUDED.value,
+                    updated_at = EXCLUDED.updated_at
+            """,
+            new { key = SettingsKey, value = json, }).ConfigureAwait(false);
+    }
+}

--- a/src/NexJob.Postgres/SchemaMigrator.cs
+++ b/src/NexJob.Postgres/SchemaMigrator.cs
@@ -20,6 +20,7 @@ internal sealed class SchemaMigrator
         new(4, "create schema_version and recurring_locks tables", SchemaSql.V4CreateVersionTable),
         new(5, "add progress_percent, progress_message, tags columns", SchemaSql.V5AddProgressAndTags),
         new(6, "create active servers table", SchemaSql.V6CreateServersTable),
+        new(7, "create nexjob_settings table for runtime configuration", SchemaSql.V7CreateSettingsTable),
     ];
 
     // Arbitrary but stable numeric key for pg_advisory_lock: hash of 'nexjob'

--- a/src/NexJob.Postgres/SchemaSQL.cs
+++ b/src/NexJob.Postgres/SchemaSQL.cs
@@ -115,6 +115,16 @@ internal static class SchemaSql
         );
         """;
 
+    /// <summary>V7: Create nexjob_settings table for persistent runtime configuration.</summary>
+    internal const string V7CreateSettingsTable =
+        """
+        CREATE TABLE IF NOT EXISTS nexjob_settings (
+            key        TEXT        PRIMARY KEY,
+            value      TEXT        NOT NULL,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        """;
+
     /// <summary>Full initial schema — kept for backward compatibility. Prefer the versioned consts.</summary>
     internal const string CreateTables = V1CreateTables;
 }

--- a/src/NexJob.Redis/NexJobRedisExtensions.cs
+++ b/src/NexJob.Redis/NexJobRedisExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using NexJob.Configuration;
 using NexJob.Storage;
 using StackExchange.Redis;
 
@@ -19,11 +20,9 @@ public static class NexJobRedisExtensions
         this IServiceCollection services,
         string connectionString)
     {
-        services.AddSingleton<IStorageProvider>(_ =>
-        {
-            var mux = ConnectionMultiplexer.Connect(connectionString);
-            return new RedisStorageProvider(mux.GetDatabase());
-        });
+        var mux = ConnectionMultiplexer.Connect(connectionString);
+        services.AddSingleton<IStorageProvider>(_ => new RedisStorageProvider(mux.GetDatabase()));
+        services.AddSingleton<IRuntimeSettingsStore>(_ => new RedisRuntimeSettingsStore(mux.GetDatabase()));
 
         return services;
     }
@@ -41,6 +40,8 @@ public static class NexJobRedisExtensions
     {
         services.AddSingleton<IStorageProvider>(
             _ => new RedisStorageProvider(multiplexer.GetDatabase()));
+        services.AddSingleton<IRuntimeSettingsStore>(
+            _ => new RedisRuntimeSettingsStore(multiplexer.GetDatabase()));
 
         return services;
     }

--- a/src/NexJob.Redis/RedisRuntimeSettingsStore.cs
+++ b/src/NexJob.Redis/RedisRuntimeSettingsStore.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using NexJob.Configuration;
+using StackExchange.Redis;
+
+namespace NexJob.Redis;
+
+/// <summary>
+/// Redis-backed implementation of <see cref="IRuntimeSettingsStore"/>.
+/// Persists runtime configuration as a JSON string at <c>nexjob:settings:runtime</c>
+/// so that dashboard overrides survive application restarts.
+/// </summary>
+public sealed class RedisRuntimeSettingsStore : IRuntimeSettingsStore
+{
+    private const string SettingsKey = "nexjob:settings:runtime";
+    private readonly IDatabase _db;
+
+    /// <summary>Initializes a new <see cref="RedisRuntimeSettingsStore"/>.</summary>
+    public RedisRuntimeSettingsStore(IDatabase db)
+    {
+        _db = db;
+    }
+
+    /// <inheritdoc/>
+    public async Task<RuntimeSettings> GetAsync(CancellationToken ct = default)
+    {
+        var json = await _db.StringGetAsync(SettingsKey).ConfigureAwait(false);
+
+        return json.IsNullOrEmpty
+            ? new RuntimeSettings()
+            : JsonSerializer.Deserialize<RuntimeSettings>(json.ToString()) ?? new RuntimeSettings();
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveAsync(RuntimeSettings settings, CancellationToken ct = default)
+    {
+        settings.UpdatedAt = DateTimeOffset.UtcNow;
+        var json = JsonSerializer.Serialize(settings);
+        await _db.StringSetAsync(SettingsKey, json).ConfigureAwait(false);
+    }
+}

--- a/src/NexJob.SqlServer/NexJobSqlServerExtensions.cs
+++ b/src/NexJob.SqlServer/NexJobSqlServerExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using NexJob.Configuration;
 using NexJob.Storage;
 
 namespace NexJob.SqlServer;
@@ -19,6 +20,7 @@ public static class NexJobSqlServerExtensions
         string connectionString)
     {
         services.AddSingleton<IStorageProvider>(_ => new SqlServerStorageProvider(connectionString));
+        services.AddSingleton<IRuntimeSettingsStore>(_ => new SqlServerRuntimeSettingsStore(connectionString));
         return services;
     }
 }

--- a/src/NexJob.SqlServer/SchemaMigrator.cs
+++ b/src/NexJob.SqlServer/SchemaMigrator.cs
@@ -20,6 +20,7 @@ internal sealed class SchemaMigrator
         new(4, "create schema_version and recurring_locks tables", SqlServerSchemaSql.V4CreateVersionTable),
         new(5, "add progress_percent, progress_message, tags columns", SqlServerSchemaSql.V5AddProgressAndTags),
         new(6, "add nexjob_servers table for active server tracking", SqlServerSchemaSql.V6CreateServersTable),
+        new(7, "create nexjob_settings table for runtime configuration", SqlServerSchemaSql.V7CreateSettingsTable),
     ];
 
     /// <summary>

--- a/src/NexJob.SqlServer/SqlServerRuntimeSettingsStore.cs
+++ b/src/NexJob.SqlServer/SqlServerRuntimeSettingsStore.cs
@@ -1,0 +1,62 @@
+#pragma warning disable MA0004
+using System.Text.Json;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using NexJob.Configuration;
+
+namespace NexJob.SqlServer;
+
+/// <summary>
+/// SQL Server-backed implementation of <see cref="IRuntimeSettingsStore"/>.
+/// Persists runtime configuration in the <c>nexjob_settings</c> table so that
+/// dashboard overrides survive application restarts.
+/// </summary>
+public sealed class SqlServerRuntimeSettingsStore : IRuntimeSettingsStore
+{
+    private const string SettingsKey = "runtime_settings";
+    private readonly string _connectionString;
+
+    /// <summary>Initializes a new <see cref="SqlServerRuntimeSettingsStore"/>.</summary>
+    public SqlServerRuntimeSettingsStore(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    /// <inheritdoc/>
+    public async Task<RuntimeSettings> GetAsync(CancellationToken ct = default)
+    {
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+
+        var json = await conn.ExecuteScalarAsync<string?>(
+            "SELECT value FROM nexjob_settings WHERE [key] = @key",
+            new { key = SettingsKey, }).ConfigureAwait(false);
+
+        return json is null
+            ? new RuntimeSettings()
+            : JsonSerializer.Deserialize<RuntimeSettings>(json) ?? new RuntimeSettings();
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveAsync(RuntimeSettings settings, CancellationToken ct = default)
+    {
+        settings.UpdatedAt = DateTimeOffset.UtcNow;
+        var json = JsonSerializer.Serialize(settings);
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+
+        await conn.ExecuteAsync(
+            """
+            MERGE nexjob_settings WITH (HOLDLOCK) AS target
+            USING (SELECT @key AS [key], @value AS [value]) AS source
+                ON target.[key] = source.[key]
+            WHEN MATCHED THEN
+                UPDATE SET [value] = source.[value], updated_at = SYSDATETIMEOFFSET()
+            WHEN NOT MATCHED THEN
+                INSERT ([key], [value], updated_at)
+                VALUES (source.[key], source.[value], SYSDATETIMEOFFSET());
+            """,
+            new { key = SettingsKey, value = json, }).ConfigureAwait(false);
+    }
+}

--- a/src/NexJob.SqlServer/SqlServerSchemaSql.cs
+++ b/src/NexJob.SqlServer/SqlServerSchemaSql.cs
@@ -131,6 +131,17 @@ internal static class SqlServerSchemaSql
             WHERE heartbeat_at IS NOT NULL;
         """;
 
+    /// <summary>V7: Create nexjob_settings table for persistent runtime configuration.</summary>
+    internal const string V7CreateSettingsTable =
+        """
+        IF OBJECT_ID('nexjob_settings', 'U') IS NULL
+        CREATE TABLE nexjob_settings (
+            [key]      NVARCHAR(200) PRIMARY KEY,
+            [value]    NVARCHAR(MAX) NOT NULL,
+            updated_at DATETIMEOFFSET NOT NULL DEFAULT SYSDATETIMEOFFSET()
+        );
+        """;
+
     /// <summary>Full initial schema — kept for backward compatibility. Prefer the versioned consts.</summary>
     internal const string CreateTables = V1CreateTables;
 }

--- a/tests/NexJob.IntegrationTests/MongoRuntimeSettingsStoreTests.cs
+++ b/tests/NexJob.IntegrationTests/MongoRuntimeSettingsStoreTests.cs
@@ -1,0 +1,29 @@
+using MongoDB.Driver;
+using NexJob.Configuration;
+using NexJob.MongoDB;
+using Xunit;
+
+namespace NexJob.IntegrationTests;
+
+/// <summary>
+/// Tests <see cref="MongoRuntimeSettingsStore"/> contract against a real MongoDB instance.
+/// Requires Docker to be available on the host.
+/// </summary>
+public sealed class MongoRuntimeSettingsStoreTests
+    : RuntimeSettingsStoreTestsBase, IClassFixture<MongoFixture>
+{
+    private readonly MongoFixture _fixture;
+
+    public MongoRuntimeSettingsStoreTests(MongoFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    protected override async Task<IRuntimeSettingsStore> CreateStoreAsync()
+    {
+        var client = new MongoClient(_fixture.Container.GetConnectionString());
+        var dbName = $"nexjob_rt_{Guid.NewGuid():N}";
+        var database = client.GetDatabase(dbName);
+        return await Task.FromResult(new MongoRuntimeSettingsStore(database));
+    }
+}

--- a/tests/NexJob.IntegrationTests/PostgresRuntimeSettingsStoreTests.cs
+++ b/tests/NexJob.IntegrationTests/PostgresRuntimeSettingsStoreTests.cs
@@ -1,0 +1,39 @@
+using NexJob.Configuration;
+using NexJob.Postgres;
+using Xunit;
+
+namespace NexJob.IntegrationTests;
+
+/// <summary>
+/// Tests <see cref="PostgresRuntimeSettingsStore"/> contract against a real PostgreSQL instance.
+/// Requires Docker to be available on the host.
+/// </summary>
+public sealed class PostgresRuntimeSettingsStoreTests
+    : RuntimeSettingsStoreTestsBase, IClassFixture<PostgresFixture>
+{
+    private readonly PostgresFixture _fixture;
+
+    public PostgresRuntimeSettingsStoreTests(PostgresFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    protected override async Task<IRuntimeSettingsStore> CreateStoreAsync()
+    {
+        var baseConn = _fixture.Container.GetConnectionString();
+        var dbName = $"nexjob_rt_{Guid.NewGuid():N}";
+
+        using var conn = new Npgsql.NpgsqlConnection(baseConn);
+        await conn.OpenAsync();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"CREATE DATABASE {dbName};";
+        await cmd.ExecuteNonQueryAsync();
+
+        var cs = new Npgsql.NpgsqlConnectionStringBuilder(baseConn) { Database = dbName, }.ToString();
+
+        // Create a storage provider to trigger migrations (which will create nexjob_settings table)
+        new PostgresStorageProvider(cs);
+
+        return new PostgresRuntimeSettingsStore(cs);
+    }
+}

--- a/tests/NexJob.IntegrationTests/RedisRuntimeSettingsStoreTests.cs
+++ b/tests/NexJob.IntegrationTests/RedisRuntimeSettingsStoreTests.cs
@@ -1,0 +1,32 @@
+using NexJob.Configuration;
+using NexJob.Redis;
+using StackExchange.Redis;
+using Xunit;
+
+namespace NexJob.IntegrationTests;
+
+/// <summary>
+/// Tests <see cref="RedisRuntimeSettingsStore"/> contract against a real Redis instance.
+/// Requires Docker to be available on the host.
+/// </summary>
+public sealed class RedisRuntimeSettingsStoreTests
+    : RuntimeSettingsStoreTestsBase, IClassFixture<RedisFixture>
+{
+    private readonly RedisFixture _fixture;
+
+    public RedisRuntimeSettingsStoreTests(RedisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    protected override async Task<IRuntimeSettingsStore> CreateStoreAsync()
+    {
+        var mux = await ConnectionMultiplexer.ConnectAsync(_fixture.Container.GetConnectionString()).ConfigureAwait(false);
+        var db = mux.GetDatabase();
+
+        // Flush to ensure clean state per test run
+        await db.ExecuteAsync("FLUSHDB").ConfigureAwait(false);
+
+        return new RedisRuntimeSettingsStore(db);
+    }
+}

--- a/tests/NexJob.IntegrationTests/RuntimeSettingsStoreTestsBase.cs
+++ b/tests/NexJob.IntegrationTests/RuntimeSettingsStoreTestsBase.cs
@@ -1,0 +1,91 @@
+using FluentAssertions;
+using NexJob.Configuration;
+using Xunit;
+
+namespace NexJob.IntegrationTests;
+
+/// <summary>
+/// Abstract contract tests for <see cref="IRuntimeSettingsStore"/> implementations.
+/// </summary>
+public abstract class RuntimeSettingsStoreTestsBase
+{
+    /// <summary>Creates and returns a ready-to-use runtime settings store for a clean test run.</summary>
+    protected abstract Task<IRuntimeSettingsStore> CreateStoreAsync();
+
+    [Fact]
+    public async Task GetAsync_WhenEmpty_ReturnsDefaultSettings()
+    {
+        var store = await CreateStoreAsync();
+        var settings = await store.GetAsync();
+
+        settings.Should().NotBeNull();
+        settings.Workers.Should().BeNull();
+        settings.PollingInterval.Should().BeNull();
+        settings.PausedQueues.Should().BeEmpty();
+        settings.RecurringJobsPaused.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SaveAsync_ThenGetAsync_ReturnsSavedSettings()
+    {
+        var store = await CreateStoreAsync();
+
+        var saved = new RuntimeSettings
+        {
+            Workers = 5,
+            PollingInterval = TimeSpan.FromSeconds(30),
+            PausedQueues = ["critical", "bulk"],
+            RecurringJobsPaused = true,
+        };
+
+        await store.SaveAsync(saved);
+        var loaded = await store.GetAsync();
+
+        loaded.Workers.Should().Be(5);
+        loaded.PollingInterval.Should().Be(TimeSpan.FromSeconds(30));
+        loaded.PausedQueues.Should().Contain("critical").And.Contain("bulk");
+        loaded.RecurringJobsPaused.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SaveAsync_CalledTwice_OverwritesPreviousSettings()
+    {
+        var store = await CreateStoreAsync();
+
+        await store.SaveAsync(new RuntimeSettings { Workers = 3, });
+        await store.SaveAsync(new RuntimeSettings { Workers = 7, });
+
+        var loaded = await store.GetAsync();
+        loaded.Workers.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task SaveAsync_SetsUpdatedAt()
+    {
+        var store = await CreateStoreAsync();
+        var before = DateTimeOffset.UtcNow.AddSeconds(-1);
+
+        await store.SaveAsync(new RuntimeSettings { Workers = 2, });
+        var loaded = await store.GetAsync();
+
+        loaded.UpdatedAt.Should().BeAfter(before);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithNullOverrides_RoundTripsCorrectly()
+    {
+        var store = await CreateStoreAsync();
+
+        await store.SaveAsync(new RuntimeSettings
+        {
+            Workers = null,
+            PollingInterval = null,
+            RecurringJobsPaused = false,
+        });
+
+        var loaded = await store.GetAsync();
+        loaded.Workers.Should().BeNull();
+        loaded.PollingInterval.Should().BeNull();
+        loaded.RecurringJobsPaused.Should().BeFalse();
+    }
+}

--- a/tests/NexJob.IntegrationTests/SqlServerRuntimeSettingsStoreTests.cs
+++ b/tests/NexJob.IntegrationTests/SqlServerRuntimeSettingsStoreTests.cs
@@ -1,0 +1,44 @@
+using NexJob.Configuration;
+using NexJob.SqlServer;
+using Xunit;
+
+namespace NexJob.IntegrationTests;
+
+/// <summary>
+/// Tests <see cref="SqlServerRuntimeSettingsStore"/> contract against a real SQL Server instance.
+/// Requires Docker to be available on the host.
+/// </summary>
+public sealed class SqlServerRuntimeSettingsStoreTests
+    : RuntimeSettingsStoreTestsBase, IClassFixture<SqlServerFixture>
+{
+    private readonly SqlServerFixture _fixture;
+
+    public SqlServerRuntimeSettingsStoreTests(SqlServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    protected override async Task<IRuntimeSettingsStore> CreateStoreAsync()
+    {
+        var baseConn = _fixture.Container.GetConnectionString();
+        var dbName = $"NexJob_RT_{Guid.NewGuid():N}";
+
+        using var conn = new Microsoft.Data.SqlClient.SqlConnection(baseConn);
+        await conn.OpenAsync();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"CREATE DATABASE [{dbName}];";
+        await cmd.ExecuteNonQueryAsync();
+
+        var builder = new Microsoft.Data.SqlClient.SqlConnectionStringBuilder(baseConn)
+        {
+            InitialCatalog = dbName,
+        };
+
+        var cs = builder.ConnectionString;
+
+        // Create a storage provider to trigger migrations (which will create nexjob_settings table)
+        new SqlServerStorageProvider(cs);
+
+        return new SqlServerRuntimeSettingsStore(cs);
+    }
+}

--- a/tests/NexJob.Tests/SchemaMigratorTests.cs
+++ b/tests/NexJob.Tests/SchemaMigratorTests.cs
@@ -17,7 +17,7 @@ public sealed class SchemaMigratorTests
     [Fact]
     public void Postgres_GetPending_AllApplied_ReturnsEmpty()
     {
-        var applied = new HashSet<int> { 1, 2, 3, 4, 5, 6 };
+        var applied = new HashSet<int> { 1, 2, 3, 4, 5, 6, 7 };
 
         var pending = NexJob.Postgres.SchemaMigrator
             .GetPendingMigrations(NexJob.Postgres.SchemaMigrator.AllMigrations, applied);
@@ -45,21 +45,21 @@ public sealed class SchemaMigratorTests
             .GetPendingMigrations(NexJob.Postgres.SchemaMigrator.AllMigrations, applied)
             .ToList();
 
-        pending.Should().HaveCount(4);
-        pending.Select(m => m.Version).Should().Equal(3, 4, 5, 6);
+        pending.Should().HaveCount(5);
+        pending.Select(m => m.Version).Should().Equal(3, 4, 5, 6, 7);
     }
 
     [Fact]
     public void Postgres_GetPending_OutOfOrderApplied_ReturnsCorrect()
     {
-        // Versions 1 and 3 applied; 2, 4, and 5 missing
+        // Versions 1 and 3 applied; 2, 4, 5, 6, 7 missing
         var applied = new HashSet<int> { 1, 3 };
 
         var pending = NexJob.Postgres.SchemaMigrator
             .GetPendingMigrations(NexJob.Postgres.SchemaMigrator.AllMigrations, applied)
             .ToList();
 
-        pending.Select(m => m.Version).Should().Equal(2, 4, 5, 6);
+        pending.Select(m => m.Version).Should().Equal(2, 4, 5, 6, 7);
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public sealed class SchemaMigratorTests
     [Fact]
     public void SqlServer_GetPending_AllApplied_ReturnsEmpty()
     {
-        var applied = new HashSet<int> { 1, 2, 3, 4, 5, 6 };
+        var applied = new HashSet<int> { 1, 2, 3, 4, 5, 6, 7 };
 
         var pending = NexJob.SqlServer.SchemaMigrator
             .GetPendingMigrations(NexJob.SqlServer.SchemaMigrator.AllMigrations, applied);
@@ -111,8 +111,8 @@ public sealed class SchemaMigratorTests
             .GetPendingMigrations(NexJob.SqlServer.SchemaMigrator.AllMigrations, applied)
             .ToList();
 
-        pending.Should().HaveCount(4);
-        pending.Select(m => m.Version).Should().Equal(3, 4, 5, 6);
+        pending.Should().HaveCount(5);
+        pending.Select(m => m.Version).Should().Equal(3, 4, 5, 6, 7);
     }
 
     [Fact]
@@ -124,7 +124,7 @@ public sealed class SchemaMigratorTests
             .GetPendingMigrations(NexJob.SqlServer.SchemaMigrator.AllMigrations, applied)
             .ToList();
 
-        pending.Select(m => m.Version).Should().Equal(2, 4, 5, 6);
+        pending.Select(m => m.Version).Should().Equal(2, 4, 5, 6, 7);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Implement persistent `IRuntimeSettingsStore` for all storage providers (PostgreSQL, SQL Server, Redis, MongoDB). Runtime configuration overrides made via the dashboard (worker count, polling interval, paused queues, recurring jobs paused) now survive application restarts.

## Type of change
- [x] New feature

## Checklist
- [x] `dotnet build` passes with **0 warnings**
- [x] `dotnet test` passes — no regressions
- [x] New behaviour is covered by tests (5 unit tests in base + 20 integration tests across 4 providers)
- [x] Public API has XML documentation (`///`)
- [x] Commit messages follow Conventional Commits

## Implementation Details
- **V7 migrations**: PostgreSQL and SQL Server add `nexjob_settings` table
- **Stores**: Each provider implements `IRuntimeSettingsStore` with Get/Save methods
- **Serialization**: `System.Text.Json` for runtime settings (standard for project)
- **Registration**: Automatic via `AddNexJobXxx()` methods (singleton)
- **Tests**: Contract tests via `RuntimeSettingsStoreTestsBase`; integration tests against real containers

**Non-goals**: InMemoryRuntimeSettingsStore remains volatile (by design); dashboard UI unchanged.
