### PR TITLE
feat(retention): automatic cleanup of terminal jobs with configurable TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **`ContinueWithAsync<TJob>`** — new no-input overload for chaining `IJob` continuations after a parent job completes.
 - **`ThrottleAttribute` documentation** — clarified that concurrency limits are enforced per worker process (local), not cluster-wide.
 - **Persistent `IRuntimeSettingsStore`** — all four storage providers (PostgreSQL, SQL Server, Redis, MongoDB) now implement `IRuntimeSettingsStore`, persisting runtime configuration (worker count, polling interval, paused queues, recurring jobs paused) across application restarts. Dashboard overrides no longer require reapplication after each deploy. The in-memory store remains as fallback when no persistent provider is configured.
+- **Job Retention — automatic cleanup of terminal jobs** — new `JobRetentionService` periodically purges `Succeeded`, `Failed`, and `Expired` jobs older than configurable retention thresholds. Defaults: Succeeded 7 days, Failed 30 days, Expired 7 days. Thresholds are configurable via `NexJobOptions` (code/appsettings) and overridable at runtime through the dashboard Settings page without restart. Setting a threshold to zero disables purging for that status. `RetentionPolicy` type and `IStorageProvider.PurgeJobsAsync` implemented in all five storage providers.
 
 ### Changed
 

--- a/src/NexJob.Dashboard/DashboardMiddleware.cs
+++ b/src/NexJob.Dashboard/DashboardMiddleware.cs
@@ -391,6 +391,33 @@ public sealed class DashboardMiddleware
             return true;
         }
 
+        if (string.Equals(subPath, "settings/retention", StringComparison.Ordinal))
+        {
+            var form = await context.Request.ReadFormAsync(context.RequestAborted).ConfigureAwait(false);
+
+            var rt = await runtimeStore.GetAsync(context.RequestAborted).ConfigureAwait(false);
+
+            if (int.TryParse(form["retentionSucceededDays"], NumberStyles.Integer, CultureInfo.InvariantCulture, out var succDays) && succDays >= 0)
+            {
+                rt.RetentionSucceeded = succDays == 0 ? TimeSpan.Zero : TimeSpan.FromDays(succDays);
+            }
+
+            if (int.TryParse(form["retentionFailedDays"], NumberStyles.Integer, CultureInfo.InvariantCulture, out var failDays) && failDays >= 0)
+            {
+                rt.RetentionFailed = failDays == 0 ? TimeSpan.Zero : TimeSpan.FromDays(failDays);
+            }
+
+            if (int.TryParse(form["retentionExpiredDays"], NumberStyles.Integer, CultureInfo.InvariantCulture, out var expDays) && expDays >= 0)
+            {
+                rt.RetentionExpired = expDays == 0 ? TimeSpan.Zero : TimeSpan.FromDays(expDays);
+            }
+
+            await runtimeStore.SaveAsync(rt, context.RequestAborted).ConfigureAwait(false);
+
+            LocalRedirect(context, $"{_pathPrefix}/settings");
+            return true;
+        }
+
         if (subPath.StartsWith("queues/", StringComparison.Ordinal) && subPath.EndsWith("/pause", StringComparison.Ordinal))
         {
             var queueName = Uri.UnescapeDataString(subPath.Split('/')[1]);

--- a/src/NexJob.Dashboard/Pages/SettingsPage.cs
+++ b/src/NexJob.Dashboard/Pages/SettingsPage.cs
@@ -42,6 +42,9 @@ internal sealed class SettingsPage : ComponentBase
     {
         var effectiveWorkers = Runtime.Workers ?? Options.Workers;
         var effectivePolling = (Runtime.PollingInterval ?? Options.PollingInterval).TotalSeconds;
+        var effectiveRetentionSucceeded = (int)(Runtime.RetentionSucceeded ?? Options.RetentionSucceeded).TotalDays;
+        var effectiveRetentionFailed = (int)(Runtime.RetentionFailed ?? Options.RetentionFailed).TotalDays;
+        var effectiveRetentionExpired = (int)(Runtime.RetentionExpired ?? Options.RetentionExpired).TotalDays;
 
         var effectiveJson = JsonSerializer.Serialize(new
         {
@@ -53,15 +56,26 @@ internal sealed class SettingsPage : ComponentBase
             Queues = Options.Queues,
             PausedQueues = Runtime.PausedQueues,
             RecurringJobsPaused = Runtime.RecurringJobsPaused,
+            RetentionSucceededDays = effectiveRetentionSucceeded,
+            RetentionFailedDays = effectiveRetentionFailed,
+            RetentionExpiredDays = effectiveRetentionExpired,
             RuntimeOverrides = new
             {
                 Runtime.Workers,
                 Runtime.PollingInterval,
+                Runtime.RetentionSucceeded,
+                Runtime.RetentionFailed,
+                Runtime.RetentionExpired,
                 Runtime.UpdatedAt,
             },
         }, PrettyPrint);
 
-        var hasOverrides = Runtime.Workers.HasValue || Runtime.PollingInterval.HasValue || Runtime.PausedQueues.Count > 0;
+        var hasOverrides = Runtime.Workers.HasValue
+            || Runtime.PollingInterval.HasValue
+            || Runtime.PausedQueues.Count > 0
+            || Runtime.RetentionSucceeded.HasValue
+            || Runtime.RetentionFailed.HasValue
+            || Runtime.RetentionExpired.HasValue;
 
         var body =
             "<div class=\"page-header\"><div>" +
@@ -107,6 +121,52 @@ internal sealed class SettingsPage : ComponentBase
             "<div class=\"settings-card-header\">Queues</div>" +
             "<div class=\"settings-card-body\">" +
             BuildQueueRows() +
+            "</div></div>" +
+
+            // Retention card
+            "<div class=\"settings-card\">" +
+            "<div class=\"settings-card-header\">Retention Policy</div>" +
+            "<div class=\"settings-card-body\">" +
+            "<div class=\"settings-row\">" +
+            "<div class=\"settings-row-label\"><div>Succeeded jobs (days)</div>" +
+            $"<div class=\"settings-row-sub\">Baseline from config: {Options.RetentionSucceeded.TotalDays}d</div></div>" +
+            $"<form method=\"post\" action=\"{PathPrefix}/settings/retention\" style=\"display:flex;gap:8px;align-items:center\">" +
+            $"<input type=\"hidden\" name=\"retentionFailedDays\" value=\"{effectiveRetentionFailed}\" />" +
+            $"<input type=\"hidden\" name=\"retentionExpiredDays\" value=\"{effectiveRetentionExpired}\" />" +
+            $"<input type=\"number\" name=\"retentionSucceededDays\" value=\"{effectiveRetentionSucceeded}\" min=\"0\" max=\"3650\" " +
+            $"style=\"width:80px;padding:5px 8px;background:var(--surface2);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px\"/>" +
+            "<span style=\"font-size:12px;color:var(--text-3)\">days</span>" +
+            "<button class=\"btn btn-primary btn-sm\" type=\"submit\">Save</button>" +
+            "</form>" +
+            "</div>" +
+            "<div class=\"settings-row\">" +
+            "<div class=\"settings-row-label\"><div>Failed jobs (days)</div>" +
+            $"<div class=\"settings-row-sub\">Baseline from config: {Options.RetentionFailed.TotalDays}d</div></div>" +
+            $"<form method=\"post\" action=\"{PathPrefix}/settings/retention\" style=\"display:flex;gap:8px;align-items:center\">" +
+            $"<input type=\"hidden\" name=\"retentionSucceededDays\" value=\"{effectiveRetentionSucceeded}\" />" +
+            $"<input type=\"hidden\" name=\"retentionExpiredDays\" value=\"{effectiveRetentionExpired}\" />" +
+            $"<input type=\"number\" name=\"retentionFailedDays\" value=\"{effectiveRetentionFailed}\" min=\"0\" max=\"3650\" " +
+            $"style=\"width:80px;padding:5px 8px;background:var(--surface2);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px\"/>" +
+            "<span style=\"font-size:12px;color:var(--text-3)\">days</span>" +
+            "<button class=\"btn btn-primary btn-sm\" type=\"submit\">Save</button>" +
+            "</form>" +
+            "</div>" +
+            "<div class=\"settings-row\">" +
+            "<div class=\"settings-row-label\"><div>Expired jobs (days)</div>" +
+            $"<div class=\"settings-row-sub\">Baseline from config: {Options.RetentionExpired.TotalDays}d</div></div>" +
+            $"<form method=\"post\" action=\"{PathPrefix}/settings/retention\" style=\"display:flex;gap:8px;align-items:center\">" +
+            $"<input type=\"hidden\" name=\"retentionSucceededDays\" value=\"{effectiveRetentionSucceeded}\" />" +
+            $"<input type=\"hidden\" name=\"retentionFailedDays\" value=\"{effectiveRetentionFailed}\" />" +
+            $"<input type=\"number\" name=\"retentionExpiredDays\" value=\"{effectiveRetentionExpired}\" min=\"0\" max=\"3650\" " +
+            $"style=\"width:80px;padding:5px 8px;background:var(--surface2);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px\"/>" +
+            "<span style=\"font-size:12px;color:var(--text-3)\">days</span>" +
+            "<button class=\"btn btn-primary btn-sm\" type=\"submit\">Save</button>" +
+            "</form>" +
+            "</div>" +
+            (Runtime.RetentionSucceeded.HasValue || Runtime.RetentionFailed.HasValue || Runtime.RetentionExpired.HasValue
+                ? "<div class=\"settings-row\"><div class=\"alert alert-warning\" style=\"margin:0;flex:1\">⚠ Runtime override active — differs from appsettings baseline</div></div>"
+                : string.Empty) +
+            "<div class=\"settings-row\" style=\"color:var(--text-3);font-size:12px;margin-top:8px\"><p style=\"margin:0\">Set to 0 to disable purging for that status</p></div>" +
             "</div></div>" +
 
             // Recurring jobs card

--- a/src/NexJob.MongoDB/MongoStorageProvider.cs
+++ b/src/NexJob.MongoDB/MongoStorageProvider.cs
@@ -690,6 +690,48 @@ public sealed class MongoStorageProvider : IStorageProvider
         return docs.Select(d => d.ToRecord()).ToList();
     }
 
+    /// <inheritdoc/>
+    public async Task<int> PurgeJobsAsync(RetentionPolicy policy, CancellationToken cancellationToken = default)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var deleted = 0;
+
+        if (policy.RetainSucceeded > TimeSpan.Zero)
+        {
+            var cutoff = now - policy.RetainSucceeded;
+            var result = await _jobs.DeleteManyAsync(
+                Builders<JobDocument>.Filter.And(
+                    Builders<JobDocument>.Filter.Eq(j => j.Status, JobStatus.Succeeded),
+                    Builders<JobDocument>.Filter.Lt(j => j.CompletedAt, cutoff)),
+                cancellationToken).ConfigureAwait(false);
+            deleted += (int)result.DeletedCount;
+        }
+
+        if (policy.RetainFailed > TimeSpan.Zero)
+        {
+            var cutoff = now - policy.RetainFailed;
+            var result = await _jobs.DeleteManyAsync(
+                Builders<JobDocument>.Filter.And(
+                    Builders<JobDocument>.Filter.Eq(j => j.Status, JobStatus.Failed),
+                    Builders<JobDocument>.Filter.Lt(j => j.CompletedAt, cutoff)),
+                cancellationToken).ConfigureAwait(false);
+            deleted += (int)result.DeletedCount;
+        }
+
+        if (policy.RetainExpired > TimeSpan.Zero)
+        {
+            var cutoff = now - policy.RetainExpired;
+            var result = await _jobs.DeleteManyAsync(
+                Builders<JobDocument>.Filter.And(
+                    Builders<JobDocument>.Filter.Eq(j => j.Status, JobStatus.Expired),
+                    Builders<JobDocument>.Filter.Lt(j => j.CreatedAt, cutoff)),
+                cancellationToken).ConfigureAwait(false);
+            deleted += (int)result.DeletedCount;
+        }
+
+        return deleted;
+    }
+
     // ── Private helpers ───────────────────────────────────────────────────────
 
     private static bool IsActiveState(JobStatus status) =>
@@ -715,6 +757,8 @@ public sealed class MongoStorageProvider : IStorageProvider
 
         await _jobs.UpdateManyAsync(filter, update, cancellationToken: ct).ConfigureAwait(false);
     }
+
+    // ── Private helpers ────────────────────────────────────────────────────────
 
     private void EnsureIndexes()
     {

--- a/src/NexJob.Postgres/PostgresStorageProvider.cs
+++ b/src/NexJob.Postgres/PostgresStorageProvider.cs
@@ -876,6 +876,50 @@ public sealed class PostgresStorageProvider : IStorageProvider
         return rows.Select(r => r.ToRecord()).ToList();
     }
 
+    /// <inheritdoc/>
+    public async Task<int> PurgeJobsAsync(RetentionPolicy policy, CancellationToken cancellationToken = default)
+    {
+        await using var conn = Open();
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        var deleted = 0;
+
+        if (policy.RetainSucceeded > TimeSpan.Zero)
+        {
+            deleted += await conn.ExecuteAsync(
+                """
+                DELETE FROM nexjob_jobs
+                WHERE status = 'Succeeded'
+                  AND completed_at < NOW() - @retention::interval
+                """,
+                new { retention = policy.RetainSucceeded, }).ConfigureAwait(false);
+        }
+
+        if (policy.RetainFailed > TimeSpan.Zero)
+        {
+            deleted += await conn.ExecuteAsync(
+                """
+                DELETE FROM nexjob_jobs
+                WHERE status = 'Failed'
+                  AND completed_at < NOW() - @retention::interval
+                """,
+                new { retention = policy.RetainFailed, }).ConfigureAwait(false);
+        }
+
+        if (policy.RetainExpired > TimeSpan.Zero)
+        {
+            deleted += await conn.ExecuteAsync(
+                """
+                DELETE FROM nexjob_jobs
+                WHERE status = 'Expired'
+                  AND created_at < NOW() - @retention::interval
+                """,
+                new { retention = policy.RetainExpired, }).ConfigureAwait(false);
+        }
+
+        return deleted;
+    }
+
     // ── Schema ────────────────────────────────────────────────────────────────
 
     private static JobStatus ParseStatus(string status) =>

--- a/src/NexJob.Redis/RedisStorageProvider.cs
+++ b/src/NexJob.Redis/RedisStorageProvider.cs
@@ -862,6 +862,81 @@ public sealed class RedisStorageProvider : IStorageProvider
         return result.OrderBy(s => s.Id, StringComparer.Ordinal).ToList();
     }
 
+    /// <inheritdoc/>
+    public async Task<int> PurgeJobsAsync(RetentionPolicy policy, CancellationToken cancellationToken = default)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var deleted = 0;
+
+        await foreach (var key in ScanJobKeysAsync().WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            var hash = await _db.HashGetAllAsync(key).ConfigureAwait(false);
+            if (hash.Length == 0)
+            {
+                continue;
+            }
+
+            var dict = ParseHash(hash);
+            var status = GetStatusFromHash(hash);
+
+            DateTimeOffset? cutoff = null;
+            TimeSpan retention = TimeSpan.Zero;
+
+            switch (status)
+            {
+                case JobStatus.Succeeded when policy.RetainSucceeded > TimeSpan.Zero:
+                {
+                    var completedAtStr = dict.GetValueOrDefault("completedAt");
+                    if (completedAtStr != null
+                        && DateTimeOffset.TryParse(completedAtStr, CultureInfo.InvariantCulture,
+                            DateTimeStyles.RoundtripKind, out var dt))
+                    {
+                        cutoff = dt;
+                    }
+
+                    retention = policy.RetainSucceeded;
+                    break;
+                }
+
+                case JobStatus.Failed when policy.RetainFailed > TimeSpan.Zero:
+                {
+                    var completedAtStr = dict.GetValueOrDefault("completedAt");
+                    if (completedAtStr != null
+                        && DateTimeOffset.TryParse(completedAtStr, CultureInfo.InvariantCulture,
+                            DateTimeStyles.RoundtripKind, out var dt))
+                    {
+                        cutoff = dt;
+                    }
+
+                    retention = policy.RetainFailed;
+                    break;
+                }
+
+                case JobStatus.Expired when policy.RetainExpired > TimeSpan.Zero:
+                {
+                    var createdAtStr = dict.GetValueOrDefault("createdAt");
+                    if (createdAtStr != null
+                        && DateTimeOffset.TryParse(createdAtStr, CultureInfo.InvariantCulture,
+                            DateTimeStyles.RoundtripKind, out var dt))
+                    {
+                        cutoff = dt;
+                    }
+
+                    retention = policy.RetainExpired;
+                    break;
+                }
+            }
+
+            if (cutoff.HasValue && now - cutoff.Value > retention)
+            {
+                await _db.KeyDeleteAsync(key).ConfigureAwait(false);
+                deleted++;
+            }
+        }
+
+        return deleted;
+    }
+
     // ── Private static helpers ────────────────────────────────────────────────
 
     private static string JobKey(string id) => $"nexjob:jobs:{id}";

--- a/src/NexJob.Redis/RedisStorageProvider.cs
+++ b/src/NexJob.Redis/RedisStorageProvider.cs
@@ -885,46 +885,46 @@ public sealed class RedisStorageProvider : IStorageProvider
             switch (status)
             {
                 case JobStatus.Succeeded when policy.RetainSucceeded > TimeSpan.Zero:
-                {
-                    var completedAtStr = dict.GetValueOrDefault("completedAt");
-                    if (completedAtStr != null
-                        && DateTimeOffset.TryParse(completedAtStr, CultureInfo.InvariantCulture,
-                            DateTimeStyles.RoundtripKind, out var dt))
                     {
-                        cutoff = dt;
-                    }
+                        var completedAtStr = dict.GetValueOrDefault("completedAt");
+                        if (completedAtStr != null
+                            && DateTimeOffset.TryParse(completedAtStr, CultureInfo.InvariantCulture,
+                                DateTimeStyles.RoundtripKind, out var dt))
+                        {
+                            cutoff = dt;
+                        }
 
-                    retention = policy.RetainSucceeded;
-                    break;
-                }
+                        retention = policy.RetainSucceeded;
+                        break;
+                    }
 
                 case JobStatus.Failed when policy.RetainFailed > TimeSpan.Zero:
-                {
-                    var completedAtStr = dict.GetValueOrDefault("completedAt");
-                    if (completedAtStr != null
-                        && DateTimeOffset.TryParse(completedAtStr, CultureInfo.InvariantCulture,
-                            DateTimeStyles.RoundtripKind, out var dt))
                     {
-                        cutoff = dt;
-                    }
+                        var completedAtStr = dict.GetValueOrDefault("completedAt");
+                        if (completedAtStr != null
+                            && DateTimeOffset.TryParse(completedAtStr, CultureInfo.InvariantCulture,
+                                DateTimeStyles.RoundtripKind, out var dt))
+                        {
+                            cutoff = dt;
+                        }
 
-                    retention = policy.RetainFailed;
-                    break;
-                }
+                        retention = policy.RetainFailed;
+                        break;
+                    }
 
                 case JobStatus.Expired when policy.RetainExpired > TimeSpan.Zero:
-                {
-                    var createdAtStr = dict.GetValueOrDefault("createdAt");
-                    if (createdAtStr != null
-                        && DateTimeOffset.TryParse(createdAtStr, CultureInfo.InvariantCulture,
-                            DateTimeStyles.RoundtripKind, out var dt))
                     {
-                        cutoff = dt;
-                    }
+                        var createdAtStr = dict.GetValueOrDefault("createdAt");
+                        if (createdAtStr != null
+                            && DateTimeOffset.TryParse(createdAtStr, CultureInfo.InvariantCulture,
+                                DateTimeStyles.RoundtripKind, out var dt))
+                        {
+                            cutoff = dt;
+                        }
 
-                    retention = policy.RetainExpired;
-                    break;
-                }
+                        retention = policy.RetainExpired;
+                        break;
+                    }
             }
 
             if (cutoff.HasValue && now - cutoff.Value > retention)

--- a/src/NexJob.SqlServer/SqlServerStorageProvider.cs
+++ b/src/NexJob.SqlServer/SqlServerStorageProvider.cs
@@ -885,6 +885,50 @@ public sealed class SqlServerStorageProvider : IStorageProvider
         return rows.Select(r => r.ToRecord()).ToList();
     }
 
+    /// <inheritdoc/>
+    public async Task<int> PurgeJobsAsync(RetentionPolicy policy, CancellationToken cancellationToken = default)
+    {
+        await using var conn = Open();
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        var deleted = 0;
+
+        if (policy.RetainSucceeded > TimeSpan.Zero)
+        {
+            deleted += await conn.ExecuteAsync(
+                """
+                DELETE FROM nexjob_jobs
+                WHERE status = 'Succeeded'
+                  AND completed_at < DATEADD(SECOND, @seconds, SYSDATETIMEOFFSET())
+                """,
+                new { seconds = -(long)policy.RetainSucceeded.TotalSeconds, }).ConfigureAwait(false);
+        }
+
+        if (policy.RetainFailed > TimeSpan.Zero)
+        {
+            deleted += await conn.ExecuteAsync(
+                """
+                DELETE FROM nexjob_jobs
+                WHERE status = 'Failed'
+                  AND completed_at < DATEADD(SECOND, @seconds, SYSDATETIMEOFFSET())
+                """,
+                new { seconds = -(long)policy.RetainFailed.TotalSeconds, }).ConfigureAwait(false);
+        }
+
+        if (policy.RetainExpired > TimeSpan.Zero)
+        {
+            deleted += await conn.ExecuteAsync(
+                """
+                DELETE FROM nexjob_jobs
+                WHERE status = 'Expired'
+                  AND created_at < DATEADD(SECOND, @seconds, SYSDATETIMEOFFSET())
+                """,
+                new { seconds = -(long)policy.RetainExpired.TotalSeconds, }).ConfigureAwait(false);
+        }
+
+        return deleted;
+    }
+
     // ── Schema ────────────────────────────────────────────────────────────────
 
     private static JobStatus ParseStatus(string status) =>

--- a/src/NexJob/Configuration/IRuntimeSettingsStore.cs
+++ b/src/NexJob/Configuration/IRuntimeSettingsStore.cs
@@ -31,6 +31,27 @@ public sealed class RuntimeSettings
     /// <summary>Override polling interval. <see langword="null"/> = use appsettings/code value.</summary>
     public TimeSpan? PollingInterval { get; set; }
 
+    /// <summary>
+    /// Override retention period for <see cref="JobStatus.Succeeded"/> jobs.
+    /// <see langword="null"/> = use <see cref="NexJobOptions.RetentionSucceeded"/> baseline.
+    /// <see cref="TimeSpan.Zero"/> = disable purging for this status.
+    /// </summary>
+    public TimeSpan? RetentionSucceeded { get; set; }
+
+    /// <summary>
+    /// Override retention period for <see cref="JobStatus.Failed"/> jobs.
+    /// <see langword="null"/> = use <see cref="NexJobOptions.RetentionFailed"/> baseline.
+    /// <see cref="TimeSpan.Zero"/> = disable purging for this status.
+    /// </summary>
+    public TimeSpan? RetentionFailed { get; set; }
+
+    /// <summary>
+    /// Override retention period for <see cref="JobStatus.Expired"/> jobs.
+    /// <see langword="null"/> = use <see cref="NexJobOptions.RetentionExpired"/> baseline.
+    /// <see cref="TimeSpan.Zero"/> = disable purging for this status.
+    /// </summary>
+    public TimeSpan? RetentionExpired { get; set; }
+
     /// <summary>Timestamp of the last save, set automatically by the store.</summary>
     public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
 }

--- a/src/NexJob/Internal/InMemoryStorageProvider.cs
+++ b/src/NexJob/Internal/InMemoryStorageProvider.cs
@@ -684,7 +684,43 @@ internal sealed class InMemoryStorageProvider : IStorageProvider
         return Task.FromResult(result);
     }
 
+    /// <inheritdoc/>
+    public Task<int> PurgeJobsAsync(RetentionPolicy policy, CancellationToken cancellationToken = default)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var toDelete = new List<Guid>();
+
+        lock (_lock)
+        {
+            toDelete = _jobs.Values
+                .Where(job => ShouldPurgeJob(job, now, policy))
+                .Select(job => job.Id.Value)
+                .ToList();
+
+            foreach (var id in toDelete)
+            {
+                _jobs.TryRemove(id, out _);
+            }
+        }
+
+        return Task.FromResult(toDelete.Count);
+    }
+
     // ─── private helpers ─────────────────────────────────────────────────────
+
+    private static bool ShouldPurgeJob(JobRecord job, DateTimeOffset now, RetentionPolicy policy) =>
+        job.Status switch
+        {
+            JobStatus.Succeeded when policy.RetainSucceeded > TimeSpan.Zero
+                && job.CompletedAt.HasValue
+                && now - job.CompletedAt.Value > policy.RetainSucceeded => true,
+            JobStatus.Failed when policy.RetainFailed > TimeSpan.Zero
+                && job.CompletedAt.HasValue
+                && now - job.CompletedAt.Value > policy.RetainFailed => true,
+            JobStatus.Expired when policy.RetainExpired > TimeSpan.Zero
+                && now - job.CreatedAt > policy.RetainExpired => true,
+            _ => false,
+        };
 
     private static int PriorityIndex(JobPriority priority) => priority switch
     {

--- a/src/NexJob/Internal/JobRetentionService.cs
+++ b/src/NexJob/Internal/JobRetentionService.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NexJob.Configuration;
+using NexJob.Storage;
+
+namespace NexJob.Internal;
+
+/// <summary>
+/// Hosted background service that periodically purges terminal jobs
+/// (<see cref="JobStatus.Succeeded"/>, <see cref="JobStatus.Failed"/>,
+/// <see cref="JobStatus.Expired"/>) older than the configured retention thresholds.
+/// Thresholds are read from <see cref="IRuntimeSettingsStore"/> on every cycle so that
+/// dashboard overrides take effect without a restart.
+/// </summary>
+internal sealed class JobRetentionService : BackgroundService
+{
+    private readonly IStorageProvider _storage;
+    private readonly IRuntimeSettingsStore _runtimeStore;
+    private readonly NexJobOptions _options;
+    private readonly ILogger<JobRetentionService> _logger;
+
+    /// <summary>Initializes a new <see cref="JobRetentionService"/>.</summary>
+    public JobRetentionService(
+        IStorageProvider storage,
+        IRuntimeSettingsStore runtimeStore,
+        NexJobOptions options,
+        ILogger<JobRetentionService> logger)
+    {
+        _storage = storage;
+        _runtimeStore = runtimeStore;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            "JobRetentionService started. Interval: {Interval}. " +
+            "Defaults — Succeeded: {Succeeded}d, Failed: {Failed}d, Expired: {Expired}d.",
+            _options.RetentionInterval,
+            _options.RetentionSucceeded.TotalDays,
+            _options.RetentionFailed.TotalDays,
+            _options.RetentionExpired.TotalDays);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_options.RetentionInterval, stoppingToken).ConfigureAwait(false);
+
+                var runtime = await _runtimeStore.GetAsync(stoppingToken).ConfigureAwait(false);
+
+                var policy = new RetentionPolicy
+                {
+                    RetainSucceeded = runtime.RetentionSucceeded ?? _options.RetentionSucceeded,
+                    RetainFailed = runtime.RetentionFailed ?? _options.RetentionFailed,
+                    RetainExpired = runtime.RetentionExpired ?? _options.RetentionExpired,
+                };
+
+                var deleted = await _storage.PurgeJobsAsync(policy, stoppingToken).ConfigureAwait(false);
+
+                if (deleted > 0)
+                {
+                    _logger.LogInformation(
+                        "JobRetentionService purged {Count} terminal job(s).", deleted);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in JobRetentionService.");
+            }
+        }
+
+        _logger.LogInformation("JobRetentionService stopped.");
+    }
+}

--- a/src/NexJob/NexJobOptions.cs
+++ b/src/NexJob/NexJobOptions.cs
@@ -101,6 +101,30 @@ public sealed class NexJobOptions
     public int MaxJobLogLines { get; set; } = 200;
 
     /// <summary>
+    /// How long to retain <see cref="JobStatus.Succeeded"/> jobs before automatic deletion.
+    /// Defaults to 7 days. Set to <see cref="TimeSpan.Zero"/> to disable purging for this status.
+    /// </summary>
+    public TimeSpan RetentionSucceeded { get; set; } = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// How long to retain <see cref="JobStatus.Failed"/> jobs before automatic deletion.
+    /// Defaults to 30 days. Set to <see cref="TimeSpan.Zero"/> to disable purging for this status.
+    /// </summary>
+    public TimeSpan RetentionFailed { get; set; } = TimeSpan.FromDays(30);
+
+    /// <summary>
+    /// How long to retain <see cref="JobStatus.Expired"/> jobs before automatic deletion.
+    /// Defaults to 7 days. Set to <see cref="TimeSpan.Zero"/> to disable purging for this status.
+    /// </summary>
+    public TimeSpan RetentionExpired { get; set; } = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// How often the retention service runs to purge old terminal jobs.
+    /// Defaults to 1 hour.
+    /// </summary>
+    public TimeSpan RetentionInterval { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
     /// Per-queue settings loaded from <c>appsettings.json</c>, used for execution windows.
     /// Populated by <see cref="ApplySettings"/>.
     /// </summary>

--- a/src/NexJob/NexJobServiceCollectionExtensions.cs
+++ b/src/NexJob/NexJobServiceCollectionExtensions.cs
@@ -157,6 +157,7 @@ public static class NexJobServiceCollectionExtensions
         services.AddHostedService<RecurringJobSchedulerService>();
         services.AddHostedService<ServerHeartbeatService>();
         services.AddHostedService<OrphanedJobWatcherService>();
+        services.AddHostedService<JobRetentionService>();
         services.AddSingleton<RecurringJobRegistrar>();
         services.AddHostedService(provider =>
             new RecurringJobRegistrationService(

--- a/src/NexJob/Storage/IStorageProvider.cs
+++ b/src/NexJob/Storage/IStorageProvider.cs
@@ -316,4 +316,16 @@ public interface IStorageProvider
     /// <param name="tag">The tag to filter by.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     Task<IReadOnlyList<JobRecord>> GetJobsByTagAsync(string tag, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Permanently deletes terminal jobs (<see cref="JobStatus.Succeeded"/>,
+    /// <see cref="JobStatus.Failed"/>, <see cref="JobStatus.Expired"/>) whose
+    /// <see cref="JobRecord.CompletedAt"/> (or <see cref="JobRecord.CreatedAt"/> for Expired)
+    /// is older than the thresholds defined in <paramref name="policy"/>.
+    /// A threshold of <see cref="TimeSpan.Zero"/> skips purging for that status.
+    /// </summary>
+    /// <param name="policy">Retention thresholds per terminal status.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>Total number of jobs deleted.</returns>
+    Task<int> PurgeJobsAsync(RetentionPolicy policy, CancellationToken cancellationToken = default);
 }

--- a/src/NexJob/Storage/RetentionPolicy.cs
+++ b/src/NexJob/Storage/RetentionPolicy.cs
@@ -1,0 +1,26 @@
+namespace NexJob.Storage;
+
+/// <summary>
+/// Defines how long completed jobs are retained before being automatically deleted.
+/// Passed to <see cref="IStorageProvider.PurgeJobsAsync"/> by the retention service.
+/// </summary>
+public sealed class RetentionPolicy
+{
+    /// <summary>
+    /// How long to retain jobs in <see cref="JobStatus.Succeeded"/> state.
+    /// Jobs older than this threshold are deleted. <see cref="TimeSpan.Zero"/> disables purging for this status.
+    /// </summary>
+    public TimeSpan RetainSucceeded { get; init; } = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// How long to retain jobs in <see cref="JobStatus.Failed"/> state.
+    /// Jobs older than this threshold are deleted. <see cref="TimeSpan.Zero"/> disables purging for this status.
+    /// </summary>
+    public TimeSpan RetainFailed { get; init; } = TimeSpan.FromDays(30);
+
+    /// <summary>
+    /// How long to retain jobs in <see cref="JobStatus.Expired"/> state.
+    /// Jobs older than this threshold are deleted. <see cref="TimeSpan.Zero"/> disables purging for this status.
+    /// </summary>
+    public TimeSpan RetainExpired { get; init; } = TimeSpan.FromDays(7);
+}

--- a/tests/NexJob.IntegrationTests/StorageProviderTestsBase.cs
+++ b/tests/NexJob.IntegrationTests/StorageProviderTestsBase.cs
@@ -756,4 +756,64 @@ public abstract class StorageProviderTestsBase
         var name = storage.GetType().Name;
         return name.Contains("Redis") || name.Contains("SqlServer");
     }
+
+    [Fact]
+    public async Task PurgeJobsAsync_DeletesTerminalJobsBeyondRetention()
+    {
+        var storage = await CreateStorageAsync();
+
+        // Use RetainSucceeded = 1 second to make test deterministic
+        var policy = new RetentionPolicy
+        {
+            RetainSucceeded = TimeSpan.FromSeconds(1),
+            RetainFailed = TimeSpan.Zero,
+            RetainExpired = TimeSpan.Zero,
+        };
+
+        var job = MakeJob();
+        await storage.EnqueueAsync(job);
+        var fetched = await storage.FetchNextAsync(["default"]);
+        await storage.CommitJobResultAsync(fetched!.Id, new JobExecutionResult
+        {
+            Succeeded = true,
+            Logs = [],
+        });
+
+        // Wait for threshold to pass
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        var deleted = await storage.PurgeJobsAsync(policy);
+
+        deleted.Should().Be(1);
+        var remaining = await storage.GetJobByIdAsync(job.Id);
+        remaining.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PurgeJobsAsync_PreservesJobsWithinRetention()
+    {
+        var storage = await CreateStorageAsync();
+
+        var policy = new RetentionPolicy
+        {
+            RetainSucceeded = TimeSpan.FromDays(7), // Long — won't purge
+            RetainFailed = TimeSpan.Zero,
+            RetainExpired = TimeSpan.Zero,
+        };
+
+        var job = MakeJob();
+        await storage.EnqueueAsync(job);
+        var fetched = await storage.FetchNextAsync(["default"]);
+        await storage.CommitJobResultAsync(fetched!.Id, new JobExecutionResult
+        {
+            Succeeded = true,
+            Logs = [],
+        });
+
+        var deleted = await storage.PurgeJobsAsync(policy);
+
+        deleted.Should().Be(0);
+        var remaining = await storage.GetJobByIdAsync(job.Id);
+        remaining.Should().NotBeNull();
+    }
 }

--- a/tests/NexJob.Tests/JobRetentionServiceTests.cs
+++ b/tests/NexJob.Tests/JobRetentionServiceTests.cs
@@ -1,0 +1,229 @@
+using FluentAssertions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using NexJob;
+using NexJob.Configuration;
+using NexJob.Internal;
+using NexJob.Storage;
+using Xunit;
+
+namespace NexJob.Tests;
+
+public sealed class JobRetentionServiceTests
+{
+    private static JobRecord MakeSucceededJob(DateTimeOffset completedAt) => new()
+    {
+        Id = JobId.New(),
+        JobType = "FakeJob",
+        InputType = "System.String",
+        InputJson = "\"test\"",
+        Queue = "default",
+        Priority = JobPriority.Normal,
+        Status = JobStatus.Succeeded,
+        CompletedAt = completedAt,
+        Attempts = 1,
+        MaxAttempts = 5,
+        CreatedAt = DateTimeOffset.UtcNow.AddDays(-10),
+    };
+
+    private static JobRecord MakeFailedJob(DateTimeOffset completedAt) => new()
+    {
+        Id = JobId.New(),
+        JobType = "FakeJob",
+        InputType = "System.String",
+        InputJson = "\"test\"",
+        Queue = "default",
+        Priority = JobPriority.Normal,
+        Status = JobStatus.Failed,
+        CompletedAt = completedAt,
+        Attempts = 5,
+        MaxAttempts = 5,
+        CreatedAt = DateTimeOffset.UtcNow.AddDays(-10),
+    };
+
+    private static JobRecord MakeExpiredJob(DateTimeOffset createdAt) => new()
+    {
+        Id = JobId.New(),
+        JobType = "FakeJob",
+        InputType = "System.String",
+        InputJson = "\"test\"",
+        Queue = "default",
+        Priority = JobPriority.Normal,
+        Status = JobStatus.Expired,
+        Attempts = 0,
+        MaxAttempts = 5,
+        CreatedAt = createdAt,
+    };
+
+    [Fact]
+    public async Task PurgeJobsAsync_DeletesSucceededJobsOlderThanRetention()
+    {
+        var storage = new InMemoryStorageProvider();
+        var now = DateTimeOffset.UtcNow;
+
+        // Job completed 8 days ago (beyond default 7-day retention)
+        var oldJob = MakeSucceededJob(now.AddDays(-8));
+        await storage.EnqueueAsync(oldJob);
+
+        var policy = new RetentionPolicy { RetainSucceeded = TimeSpan.FromDays(7), };
+
+        var deleted = await storage.PurgeJobsAsync(policy);
+
+        deleted.Should().Be(1);
+        var remaining = await storage.GetJobByIdAsync(oldJob.Id);
+        remaining.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PurgeJobsAsync_PreservesSucceededJobsWithinRetention()
+    {
+        var storage = new InMemoryStorageProvider();
+        var now = DateTimeOffset.UtcNow;
+
+        // Job completed 3 days ago (within default 7-day retention)
+        var recentJob = MakeSucceededJob(now.AddDays(-3));
+        await storage.EnqueueAsync(recentJob);
+
+        var policy = new RetentionPolicy { RetainSucceeded = TimeSpan.FromDays(7), };
+
+        var deleted = await storage.PurgeJobsAsync(policy);
+
+        deleted.Should().Be(0);
+        var remaining = await storage.GetJobByIdAsync(recentJob.Id);
+        remaining.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task PurgeJobsAsync_DeletesFailedJobsOlderThanRetention()
+    {
+        var storage = new InMemoryStorageProvider();
+        var now = DateTimeOffset.UtcNow;
+
+        // Job failed 35 days ago (beyond default 30-day retention)
+        var oldJob = MakeFailedJob(now.AddDays(-35));
+        await storage.EnqueueAsync(oldJob);
+
+        var policy = new RetentionPolicy { RetainFailed = TimeSpan.FromDays(30), };
+
+        var deleted = await storage.PurgeJobsAsync(policy);
+
+        deleted.Should().Be(1);
+        var remaining = await storage.GetJobByIdAsync(oldJob.Id);
+        remaining.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PurgeJobsAsync_DeletesExpiredJobsUsingCreatedAt()
+    {
+        var storage = new InMemoryStorageProvider();
+        var now = DateTimeOffset.UtcNow;
+
+        // Job created 8 days ago (beyond default 7-day retention)
+        var oldJob = MakeExpiredJob(now.AddDays(-8));
+        await storage.EnqueueAsync(oldJob);
+
+        var policy = new RetentionPolicy { RetainExpired = TimeSpan.FromDays(7), };
+
+        var deleted = await storage.PurgeJobsAsync(policy);
+
+        deleted.Should().Be(1);
+        var remaining = await storage.GetJobByIdAsync(oldJob.Id);
+        remaining.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PurgeJobsAsync_WhenRetainSucceededIsZero_SkipsSucceeded()
+    {
+        var storage = new InMemoryStorageProvider();
+        var now = DateTimeOffset.UtcNow;
+
+        // Old succeeded job
+        var oldJob = MakeSucceededJob(now.AddDays(-100));
+        await storage.EnqueueAsync(oldJob);
+
+        var policy = new RetentionPolicy
+        {
+            RetainSucceeded = TimeSpan.Zero,
+            RetainFailed = TimeSpan.Zero,
+            RetainExpired = TimeSpan.Zero,
+        };
+
+        var deleted = await storage.PurgeJobsAsync(policy);
+
+        deleted.Should().Be(0);
+        var remaining = await storage.GetJobByIdAsync(oldJob.Id);
+        remaining.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task PurgeJobsAsync_NeverDeletesProcessingJobs()
+    {
+        var storage = new InMemoryStorageProvider();
+
+        var processingJob = new JobRecord
+        {
+            Id = JobId.New(),
+            JobType = "FakeJob",
+            InputType = "System.String",
+            InputJson = "\"test\"",
+            Queue = "default",
+            Priority = JobPriority.Normal,
+            Status = JobStatus.Processing,
+            Attempts = 1,
+            MaxAttempts = 5,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-100),
+        };
+        await storage.EnqueueAsync(processingJob);
+
+        var policy = new RetentionPolicy
+        {
+            RetainSucceeded = TimeSpan.FromDays(1),
+            RetainFailed = TimeSpan.FromDays(1),
+            RetainExpired = TimeSpan.FromDays(1),
+        };
+
+        var deleted = await storage.PurgeJobsAsync(policy);
+
+        deleted.Should().Be(0);
+        var remaining = await storage.GetJobByIdAsync(processingJob.Id);
+        remaining.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task PurgeJobsAsync_ReturnsCorrectDeleteCount()
+    {
+        var storage = new InMemoryStorageProvider();
+        var now = DateTimeOffset.UtcNow;
+
+        // 3 old succeeded jobs
+        for (var i = 0; i < 3; i++)
+        {
+            var job = MakeSucceededJob(now.AddDays(-10));
+            await storage.EnqueueAsync(job);
+        }
+
+        // 2 old failed jobs
+        for (var i = 0; i < 2; i++)
+        {
+            var job = MakeFailedJob(now.AddDays(-40));
+            await storage.EnqueueAsync(job);
+        }
+
+        // 1 recent succeeded job (should not be deleted)
+        var recentJob = MakeSucceededJob(now.AddDays(-1));
+        await storage.EnqueueAsync(recentJob);
+
+        var policy = new RetentionPolicy
+        {
+            RetainSucceeded = TimeSpan.FromDays(7),
+            RetainFailed = TimeSpan.FromDays(30),
+            RetainExpired = TimeSpan.FromDays(7),
+        };
+
+        var deleted = await storage.PurgeJobsAsync(policy);
+
+        deleted.Should().Be(5);
+        var remaining = await storage.GetJobByIdAsync(recentJob.Id);
+        remaining.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements automatic job retention and cleanup for NexJob. Terminal jobs (Succeeded, Failed, Expired) older than configurable thresholds are automatically purged via a background service, preventing unbounded storage growth in production.

## Changes

- **RetentionPolicy type** — defines TTL thresholds per terminal job status
- **IStorageProvider.PurgeJobsAsync()** — new interface method implemented across all 5 storage providers
- **JobRetentionService** — background service running periodic purge cycles
- **NexJobOptions fields** — baseline thresholds configurable via code/appsettings (defaults: Succeeded 7d, Failed 30d, Expired 7d)
- **RuntimeSettings overrides** — dashboard-driven thresholds that take effect without restart
- **Dashboard Settings card** — Retention Policy section with live controls to adjust thresholds
- **Unit & integration tests** — 7 unit tests + 2 integration tests covering all scenarios

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist

- [x] \`dotnet build --configuration Release\` passes with **0 warnings**
- [x] Public API has XML documentation (\`///\`)
- [x] All state transitions persisted (storage is source of truth)
- [x] Follows StyleCop rules (SA1202, SA1413, SA1508, etc.)
- [x] Async/await throughout, ConfigureAwait(false) in library code
- [x] CancellationToken propagated in all async calls
- [x] Classes sealed by default
- [x] Commit message follows Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)