### PR TITLE
fix(release): prevent duplicate release step on re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,18 +45,11 @@ jobs:
           git push origin "${{ steps.version.outputs.tag }}"
 
       - name: Create or update GitHub Release
+        if: steps.tag_check.outputs.skip == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "Release ${{ steps.version.outputs.tag }} already exists — updating notes."
-            gh release edit "${{ steps.version.outputs.tag }}" \
-              --title "${{ steps.version.outputs.tag }}" \
-              --generate-notes \
-              --prerelease=${{ contains(steps.version.outputs.tag, '-') }}
-          else
-            gh release create "${{ steps.version.outputs.tag }}" \
-              --title "${{ steps.version.outputs.tag }}" \
-              --generate-notes \
-              --prerelease=${{ contains(steps.version.outputs.tag, '-') }}
-          fi
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --generate-notes \
+            --prerelease=${{ contains(steps.version.outputs.tag, '-') }}


### PR DESCRIPTION
## Summary
Fixes HTTP 422 error on release workflow re-runs. The 'Create or update GitHub Release' step ran unconditionally even when the tag already existed (skip=true), causing `gh release create` to fail.

Now gated by the same `tag_check` flag as the tag step — when a release already exists, the step is skipped entirely.

## Type of change
- [x] Bug fix

## Checklist
- [x] `release.yml` respects the skip flag in all steps
- [x] Next release will be idempotent on re-runs