### PR TITLE
refactor(scheduler): add non-generic EnqueueAsync overload

### DIFF
--- a/src/NexJob.Trigger.AwsSqs/AwsSqsTrigger.cs
+++ b/src/NexJob.Trigger.AwsSqs/AwsSqsTrigger.cs
@@ -22,8 +22,7 @@ internal sealed class AwsSqsTrigger : IHostedService
 {
     private readonly AwsSqsTriggerOptions _options;
     private readonly ISqsClient _sqsClient;
-    private readonly IStorageProvider _storage;
-    private readonly JobWakeUpChannel _wakeUpChannel;
+    private readonly IScheduler _scheduler;
     private readonly NexJobOptions _nexJobOptions;
     private readonly ILogger<AwsSqsTrigger> _logger;
 
@@ -33,18 +32,21 @@ internal sealed class AwsSqsTrigger : IHostedService
     /// <summary>
     /// Initializes a new <see cref="AwsSqsTrigger"/>.
     /// </summary>
+    /// <param name="options">AWS SQS trigger configuration.</param>
+    /// <param name="sqsClient">The SQS client for receiving messages.</param>
+    /// <param name="scheduler">The NexJob scheduler for enqueueing jobs.</param>
+    /// <param name="nexJobOptions">Global NexJob configuration options.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
     public AwsSqsTrigger(
         IOptions<AwsSqsTriggerOptions> options,
         ISqsClient sqsClient,
-        IStorageProvider storage,
-        JobWakeUpChannel wakeUpChannel,
+        IScheduler scheduler,
         NexJobOptions nexJobOptions,
         ILogger<AwsSqsTrigger> logger)
     {
         _options = options.Value;
         _sqsClient = sqsClient;
-        _storage = storage;
-        _wakeUpChannel = wakeUpChannel;
+        _scheduler = scheduler;
         _nexJobOptions = nexJobOptions;
         _logger = logger;
     }
@@ -183,11 +185,8 @@ internal sealed class AwsSqsTrigger : IHostedService
                 expiresAt: null,
                 traceParent: traceparent);
 
-            // Enqueue the job using storage provider
-            await _storage.EnqueueAsync(job, DuplicatePolicy.AllowAfterFailed, cancellationToken).ConfigureAwait(false);
-
-            // Signal wake-up channel after successful enqueue
-            _wakeUpChannel.Signal();
+            // Enqueue the job using scheduler — wake-up signal is handled internally
+            await _scheduler.EnqueueAsync(job, DuplicatePolicy.AllowAfterFailed, cancellationToken).ConfigureAwait(false);
 
             // Delete message only after successful enqueue
             var deleteRequest = new DeleteMessageRequest

--- a/src/NexJob.Trigger.AzureServiceBus/AzureServiceBusTriggerHandler.cs
+++ b/src/NexJob.Trigger.AzureServiceBus/AzureServiceBusTriggerHandler.cs
@@ -14,8 +14,7 @@ namespace NexJob.Trigger.AzureServiceBus;
 internal sealed class AzureServiceBusTriggerHandler : IHostedService
 {
     private readonly AzureServiceBusTriggerOptions _options;
-    private readonly IStorageProvider _storage;
-    private readonly JobWakeUpChannel _wakeUpChannel;
+    private readonly IScheduler _scheduler;
     private readonly NexJobOptions _nexJobOptions;
     private readonly ILogger<AzureServiceBusTriggerHandler> _logger;
 
@@ -25,16 +24,18 @@ internal sealed class AzureServiceBusTriggerHandler : IHostedService
     /// <summary>
     /// Initializes a new <see cref="AzureServiceBusTriggerHandler"/>.
     /// </summary>
+    /// <param name="options">Azure Service Bus trigger configuration.</param>
+    /// <param name="scheduler">The NexJob scheduler for enqueueing jobs.</param>
+    /// <param name="nexJobOptions">Global NexJob configuration options.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
     public AzureServiceBusTriggerHandler(
         IOptions<AzureServiceBusTriggerOptions> options,
-        IStorageProvider storage,
-        JobWakeUpChannel wakeUpChannel,
+        IScheduler scheduler,
         NexJobOptions nexJobOptions,
         ILogger<AzureServiceBusTriggerHandler> logger)
     {
         _options = options.Value;
-        _storage = storage;
-        _wakeUpChannel = wakeUpChannel;
+        _scheduler = scheduler;
         _nexJobOptions = nexJobOptions;
         _logger = logger;
     }
@@ -139,11 +140,8 @@ internal sealed class AzureServiceBusTriggerHandler : IHostedService
                 expiresAt: null,
                 traceParent: traceparent);
 
-            // Enqueue the job using storage provider
-            await _storage.EnqueueAsync(job, DuplicatePolicy.AllowAfterFailed, args.CancellationToken).ConfigureAwait(false);
-
-            // Signal wake-up channel after successful enqueue
-            _wakeUpChannel.Signal();
+            // Enqueue the job using scheduler — wake-up signal is handled internally
+            await _scheduler.EnqueueAsync(job, DuplicatePolicy.AllowAfterFailed, args.CancellationToken).ConfigureAwait(false);
 
             // Complete message only after successful enqueue
             await args.CompleteMessageAsync(args.Message, args.CancellationToken).ConfigureAwait(false);

--- a/src/NexJob/IScheduler.cs
+++ b/src/NexJob/IScheduler.cs
@@ -7,6 +7,23 @@ namespace NexJob;
 public interface IScheduler
 {
     /// <summary>
+    /// Enqueues a pre-built job record for background execution.
+    /// Use this overload when the job type is only known at runtime (e.g. broker triggers).
+    /// </summary>
+    /// <param name="job">The pre-built job record to enqueue.</param>
+    /// <param name="duplicatePolicy">
+    /// Controls behaviour when a job with the same <see cref="JobRecord.IdempotencyKey"/>
+    /// already exists in a terminal failure state. Ignored when
+    /// <see cref="JobRecord.IdempotencyKey"/> is <see langword="null"/>.
+    /// </param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>The identifier of the enqueued (or existing, if idempotent) job.</returns>
+    Task<JobId> EnqueueAsync(
+        JobRecord job,
+        DuplicatePolicy duplicatePolicy = DuplicatePolicy.AllowAfterFailed,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Immediately enqueues a no-input job for background execution.
     /// </summary>
     /// <typeparam name="TJob">The <see cref="IJob"/> implementation to execute.</typeparam>

--- a/src/NexJob/Internal/DefaultScheduler.cs
+++ b/src/NexJob/Internal/DefaultScheduler.cs
@@ -31,6 +31,42 @@ internal sealed class DefaultScheduler : IScheduler
     }
 
     /// <inheritdoc/>
+    public async Task<JobId> EnqueueAsync(
+        JobRecord job,
+        DuplicatePolicy duplicatePolicy = DuplicatePolicy.AllowAfterFailed,
+        CancellationToken cancellationToken = default)
+    {
+        using var activity = NexJobActivitySource.StartEnqueue(job.JobType, job.Queue);
+
+        var result = await _storage.EnqueueAsync(job, duplicatePolicy, cancellationToken).ConfigureAwait(false);
+
+        if (result.WasRejected && job.IdempotencyKey is not null)
+        {
+            throw new DuplicateJobException(job.IdempotencyKey, result.JobId, duplicatePolicy);
+        }
+
+        activity?.SetTag("nexjob.job_id", result.JobId.Value.ToString());
+
+        // Extract simple type name from assembly-qualified name (e.g., "MyNamespace.MyJob, ...")
+        var qualifiedName = job.JobType.Split(',')[0];
+        var simpleTypeName = qualifiedName[(qualifiedName.LastIndexOf('.') + 1)..];
+
+        NexJobMetrics.JobsEnqueued.Add(1,
+            new TagList
+            {
+                { "nexjob.job_type", simpleTypeName },
+                { "nexjob.queue", job.Queue },
+            });
+
+        if (!result.WasRejected)
+        {
+            _wakeUp.Signal();
+        }
+
+        return result.JobId;
+    }
+
+    /// <inheritdoc/>
     public async Task<JobId> EnqueueAsync<TJob, TInput>(
         TInput input,
         string? queue = null,

--- a/tests/NexJob.Trigger.AwsSqs.Tests/AwsSqsTriggerTests.cs
+++ b/tests/NexJob.Trigger.AwsSqs.Tests/AwsSqsTriggerTests.cs
@@ -20,8 +20,7 @@ public sealed class AwsSqsTriggerTests
     {
         // Arrange
         var sqsClient = new MockSqsClient();
-        var storageProvider = new MockStorageProvider();
-        var wakeUpChannel = new JobWakeUpChannel();
+        var scheduler = new MockScheduler();
         var options = Options.Create(new AwsSqsTriggerOptions
         {
             QueueUrl = "https://sqs.us-east-1.amazonaws.com/123456789/test-queue",
@@ -37,8 +36,7 @@ public sealed class AwsSqsTriggerTests
         var trigger = new AwsSqsTrigger(
             options,
             sqsClient,
-            storageProvider,
-            wakeUpChannel,
+            scheduler,
             nexJobOptions,
             logger);
 
@@ -54,12 +52,12 @@ public sealed class AwsSqsTriggerTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await trigger.StartAsync(cts.Token);
 
-        await storageProvider.WaitForEnqueueAsync(cts.Token);
+        await scheduler.WaitForEnqueueAsync(cts.Token);
         await trigger.StopAsync(cts.Token);
 
         // Assert
-        storageProvider.EnqueueCalls.Should().HaveCount(1);
-        var enqueuedJob = storageProvider.EnqueueCalls[0];
+        scheduler.EnqueueCalls.Should().HaveCount(1);
+        var enqueuedJob = scheduler.EnqueueCalls[0];
         enqueuedJob.IdempotencyKey.Should().Be("test-msg-001");
         enqueuedJob.Queue.Should().Be("default");
         enqueuedJob.TraceParent.Should().BeNull();
@@ -73,8 +71,7 @@ public sealed class AwsSqsTriggerTests
     public async Task EnqueueFailure_MessageNotDeleted()
     {
         var sqsClient = new MockSqsClient();
-        var storageProvider = new MockStorageProvider { ShouldFailEnqueue = true };
-        var wakeUpChannel = new JobWakeUpChannel();
+        var scheduler = new MockScheduler { ShouldFailEnqueue = true };
         var options = Options.Create(new AwsSqsTriggerOptions
         {
             QueueUrl = "https://sqs.us-east-1.amazonaws.com/123456789/test-queue",
@@ -90,8 +87,7 @@ public sealed class AwsSqsTriggerTests
         var trigger = new AwsSqsTrigger(
             options,
             sqsClient,
-            storageProvider,
-            wakeUpChannel,
+            scheduler,
             nexJobOptions,
             logger);
 
@@ -106,10 +102,10 @@ public sealed class AwsSqsTriggerTests
         using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await trigger.StartAsync(cts2.Token);
 
-        await storageProvider.WaitForEnqueueAttemptAsync(cts2.Token);
+        await scheduler.WaitForEnqueueAttemptAsync(cts2.Token);
         await trigger.StopAsync(cts2.Token);
 
-        storageProvider.EnqueueCalls.Should().HaveCount(1);
+        scheduler.EnqueueCalls.Should().HaveCount(1);
         sqsClient.DeleteCalls.Should().BeEmpty("enqueue failed — message should not be deleted");
     }
 
@@ -119,8 +115,7 @@ public sealed class AwsSqsTriggerTests
     public async Task VisibilityExtension_ExtendedWhileProcessing()
     {
         var sqsClient = new MockSqsClient();
-        var storageProvider = new MockStorageProvider { EnqueueDelay = TimeSpan.FromSeconds(4) };
-        var wakeUpChannel = new JobWakeUpChannel();
+        var scheduler = new MockScheduler { EnqueueDelay = TimeSpan.FromSeconds(4) };
         var options = Options.Create(new AwsSqsTriggerOptions
         {
             QueueUrl = "https://sqs.us-east-1.amazonaws.com/123456789/test-queue",
@@ -136,8 +131,7 @@ public sealed class AwsSqsTriggerTests
         var trigger = new AwsSqsTrigger(
             options,
             sqsClient,
-            storageProvider,
-            wakeUpChannel,
+            scheduler,
             nexJobOptions,
             logger);
 
@@ -152,7 +146,7 @@ public sealed class AwsSqsTriggerTests
         using var cts3 = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         await trigger.StartAsync(cts3.Token);
 
-        await storageProvider.WaitForEnqueueAsync(cts3.Token);
+        await scheduler.WaitForEnqueueAsync(cts3.Token);
         await trigger.StopAsync(cts3.Token);
 
         sqsClient.VisibilityExtensionCalls.Should().BeGreaterThanOrEqualTo(
@@ -166,8 +160,7 @@ public sealed class AwsSqsTriggerTests
     public async Task GracefulShutdown_CancellationToken_StopsCleanly()
     {
         var sqsClient = new MockSqsClient { BlockOnReceive = true };
-        var storageProvider = new MockStorageProvider();
-        var wakeUpChannel = new JobWakeUpChannel();
+        var scheduler = new MockScheduler();
         var options = Options.Create(new AwsSqsTriggerOptions
         {
             QueueUrl = "https://sqs.us-east-1.amazonaws.com/123456789/test-queue",
@@ -183,8 +176,7 @@ public sealed class AwsSqsTriggerTests
         var trigger = new AwsSqsTrigger(
             options,
             sqsClient,
-            storageProvider,
-            wakeUpChannel,
+            scheduler,
             nexJobOptions,
             logger);
 
@@ -204,8 +196,7 @@ public sealed class AwsSqsTriggerTests
     public async Task TracePropagation_TraceparentSetOnJobRecord()
     {
         var sqsClient = new MockSqsClient();
-        var storageProvider = new MockStorageProvider();
-        var wakeUpChannel = new JobWakeUpChannel();
+        var scheduler = new MockScheduler();
         var options = Options.Create(new AwsSqsTriggerOptions
         {
             QueueUrl = "https://sqs.us-east-1.amazonaws.com/123456789/test-queue",
@@ -221,8 +212,7 @@ public sealed class AwsSqsTriggerTests
         var trigger = new AwsSqsTrigger(
             options,
             sqsClient,
-            storageProvider,
-            wakeUpChannel,
+            scheduler,
             nexJobOptions,
             logger);
 
@@ -244,11 +234,11 @@ public sealed class AwsSqsTriggerTests
         using var cts5 = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await trigger.StartAsync(cts5.Token);
 
-        await storageProvider.WaitForEnqueueAsync(cts5.Token);
+        await scheduler.WaitForEnqueueAsync(cts5.Token);
         await trigger.StopAsync(cts5.Token);
 
-        storageProvider.EnqueueCalls.Should().HaveCount(1);
-        storageProvider.EnqueueCalls[0].TraceParent.Should().Be("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
+        scheduler.EnqueueCalls.Should().HaveCount(1);
+        scheduler.EnqueueCalls[0].TraceParent.Should().Be("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
     }
 
     // ─── Test job type ───────────────────────────────────────────────────────

--- a/tests/NexJob.Trigger.AwsSqs.Tests/MockScheduler.cs
+++ b/tests/NexJob.Trigger.AwsSqs.Tests/MockScheduler.cs
@@ -1,0 +1,155 @@
+namespace NexJob.Trigger.AwsSqs.Tests;
+
+/// <summary>
+/// Mock scheduler for testing. Tracks enqueue calls and optionally simulates failures.
+/// </summary>
+internal sealed class MockScheduler : IScheduler
+{
+    private readonly List<JobRecord> _enqueueCalls = [];
+    private readonly TaskCompletionSource<bool> _enqueueTcs = new();
+    private readonly TaskCompletionSource<bool> _enqueueAttemptTcs = new();
+    private readonly object _lock = new();
+
+    public bool ShouldFailEnqueue { get; set; }
+    public TimeSpan EnqueueDelay { get; set; } = TimeSpan.Zero;
+
+    public IReadOnlyList<JobRecord> EnqueueCalls
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _enqueueCalls.ToList();
+            }
+        }
+    }
+
+    public async Task<JobId> EnqueueAsync(
+        JobRecord job,
+        DuplicatePolicy duplicatePolicy = DuplicatePolicy.AllowAfterFailed,
+        CancellationToken cancellationToken = default)
+    {
+        _enqueueAttemptTcs.TrySetResult(true);
+
+        if (EnqueueDelay > TimeSpan.Zero)
+        {
+            await Task.Delay(EnqueueDelay, cancellationToken).ConfigureAwait(false);
+        }
+
+        lock (_lock)
+        {
+            _enqueueCalls.Add(job);
+        }
+
+        if (ShouldFailEnqueue)
+        {
+            throw new InvalidOperationException("Simulated enqueue failure");
+        }
+
+        _enqueueTcs.TrySetResult(true);
+        return job.Id;
+    }
+
+    public Task<JobId> EnqueueAsync<TJob>(
+        string? queue = null,
+        JobPriority priority = JobPriority.Normal,
+        string? idempotencyKey = null,
+        DuplicatePolicy duplicatePolicy = DuplicatePolicy.AllowAfterFailed,
+        IReadOnlyList<string>? tags = null,
+        TimeSpan? deadlineAfter = null,
+        CancellationToken cancellationToken = default)
+        where TJob : IJob =>
+        throw new NotSupportedException("This mock only supports the non-generic EnqueueAsync overload.");
+
+    public Task<JobId> EnqueueAsync<TJob, TInput>(
+        TInput input,
+        string? queue = null,
+        JobPriority priority = JobPriority.Normal,
+        string? idempotencyKey = null,
+        DuplicatePolicy duplicatePolicy = DuplicatePolicy.AllowAfterFailed,
+        IReadOnlyList<string>? tags = null,
+        TimeSpan? deadlineAfter = null,
+        CancellationToken cancellationToken = default)
+        where TJob : IJob<TInput> =>
+        throw new NotSupportedException("This mock only supports the non-generic EnqueueAsync overload.");
+
+    public Task<JobId> ScheduleAsync<TJob>(
+        TimeSpan delay,
+        string? queue = null,
+        string? idempotencyKey = null,
+        CancellationToken cancellationToken = default)
+        where TJob : IJob =>
+        throw new NotSupportedException("This mock only supports the non-generic EnqueueAsync overload.");
+
+    public Task<JobId> ScheduleAsync<TJob, TInput>(
+        TInput input,
+        TimeSpan delay,
+        string? queue = null,
+        string? idempotencyKey = null,
+        CancellationToken cancellationToken = default)
+        where TJob : IJob<TInput> =>
+        throw new NotSupportedException("This mock only supports the non-generic EnqueueAsync overload.");
+
+    public Task<JobId> ScheduleAtAsync<TJob>(
+        DateTimeOffset runAt,
+        string? queue = null,
+        string? idempotencyKey = null,
+        CancellationToken cancellationToken = default)
+        where TJob : IJob =>
+        throw new NotSupportedException("This mock only supports the non-generic EnqueueAsync overload.");
+
+    public Task<JobId> ScheduleAtAsync<TJob, TInput>(
+        TInput input,
+        DateTimeOffset runAt,
+        string? queue = null,
+        string? idempotencyKey = null,
+        CancellationToken cancellationToken = default)
+        where TJob : IJob<TInput> =>
+        throw new NotSupportedException("This mock only supports the non-generic EnqueueAsync overload.");
+
+    public Task RecurringAsync<TJob, TInput>(
+        string recurringJobId,
+        TInput input,
+        string cron,
+        TimeZoneInfo? timeZone = null,
+        string? queue = null,
+        RecurringConcurrencyPolicy concurrencyPolicy = RecurringConcurrencyPolicy.SkipIfRunning,
+        CancellationToken cancellationToken = default)
+        where TJob : IJob<TInput> =>
+        throw new NotSupportedException("This mock only supports the non-generic EnqueueAsync overload.");
+
+    public Task RecurringAsync<TJob>(
+        string recurringJobId,
+        string cron,
+        TimeZoneInfo? timeZone = null,
+        string? queue = null,
+        RecurringConcurrencyPolicy concurrencyPolicy = RecurringConcurrencyPolicy.SkipIfRunning,
+        CancellationToken cancellationToken = default)
+        where TJob : IJob =>
+        throw new NotSupportedException("This mock only supports the non-generic EnqueueAsync overload.");
+
+    public Task<JobId> ContinueWithAsync<TJob, TInput>(
+        JobId parentJobId,
+        TInput input,
+        string? queue = null,
+        CancellationToken cancellationToken = default)
+        where TJob : IJob<TInput> =>
+        throw new NotSupportedException("This mock only supports the non-generic EnqueueAsync overload.");
+
+    public Task<JobId> ContinueWithAsync<TJob>(
+        JobId parentJobId,
+        string? queue = null,
+        CancellationToken cancellationToken = default)
+        where TJob : IJob =>
+        throw new NotSupportedException("This mock only supports the non-generic EnqueueAsync overload.");
+
+    public Task RemoveRecurringAsync(string recurringJobId, CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("This mock only supports the non-generic EnqueueAsync overload.");
+
+    public Task<IReadOnlyList<JobRecord>> GetJobsByTagAsync(string tag, CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("This mock only supports the non-generic EnqueueAsync overload.");
+
+    public Task WaitForEnqueueAsync(CancellationToken cancellationToken) => _enqueueTcs.Task.WaitAsync(cancellationToken);
+
+    public Task WaitForEnqueueAttemptAsync(CancellationToken cancellationToken) => _enqueueAttemptTcs.Task.WaitAsync(cancellationToken);
+}


### PR DESCRIPTION
## Summary

This refactoring eliminates the architectural violation where broker triggers (Azure Service Bus, AWS SQS) were directly calling `IStorageProvider`. The root cause: `IScheduler.EnqueueAsync<TJob>` is generic and requires the job type at compile time, but triggers receive job types as runtime strings from broker messages.

Solution: add a single non-generic `EnqueueAsync(JobRecord job, DuplicatePolicy)` overload that accepts pre-built `JobRecord` instances. Triggers now depend only on `IScheduler`, not storage.

## Type of change
- [x] Refactor / cleanup

## Checklist
- [x] `dotnet build --configuration Release` passes with **0 warnings, 0 errors**
- [x] `dotnet test` passes — all tests green
- [x] Public API has XML documentation (\`///\`)
- [x] Commit messages follow Conventional Commits
- [x] Wake-up signal handling moved to scheduler (never blocks, bounded channel)
- [x] OTel activity spans and metrics identical to generic overloads

## Files changed

### Core
- \`src/NexJob/IScheduler.cs\` — add non-generic overload
- \`src/NexJob/Internal/DefaultScheduler.cs\` — implement with OTel and metrics

### Triggers (now depend only on IScheduler, not IStorageProvider)
- \`src/NexJob.Trigger.AzureServiceBus/AzureServiceBusTriggerHandler.cs\`
- \`src/NexJob.Trigger.AwsSqs/AwsSqsTrigger.cs\`

### Tests
- \`tests/NexJob.Trigger.AwsSqs.Tests/AwsSqsTriggerTests.cs\` — migrate to MockScheduler
- \`tests/NexJob.Trigger.AwsSqs.Tests/MockScheduler.cs\` — new mock (replaces MockStorageProvider in trigger tests)

## Architectural guarantees maintained

✓ Storage is single source of truth  
✓ Dispatcher is stateless  
✓ Deadline enforced before execution  
✓ Dead-letter handlers never crash  
✓ Wake-up signaling never blocks  
✓ Trigger packages independent of storage layer  

🤖 Generated with [Claude Code](https://claude.com/claude-code)