### PR TITLE
refactor(trigger.awssqs): remove obsolete architectural note

### DIFF
--- a/src/NexJob.Trigger.AwsSqs/AwsSqsTrigger.cs
+++ b/src/NexJob.Trigger.AwsSqs/AwsSqsTrigger.cs
@@ -11,13 +11,6 @@ namespace NexJob.Trigger.AwsSqs;
 /// AWS SQS trigger for NexJob. Receives messages from an SQS queue and automatically
 /// enqueues them as NexJob jobs.
 /// </summary>
-/// <remarks>
-/// ARCHITECTURAL NOTE:
-/// This trigger uses IStorageProvider directly because IScheduler is generic
-/// and requires the job type at compile time. Broker triggers receive the type
-/// as a runtime string — a non-generic IScheduler.EnqueueAsync(JobRecord) overload
-/// is needed to solve this cleanly. Tracked for v2.2.
-/// </remarks>
 internal sealed class AwsSqsTrigger : IHostedService
 {
     private readonly AwsSqsTriggerOptions _options;


### PR DESCRIPTION
## Summary
Remove obsolete <remarks> block from AwsSqsTrigger.cs class-level documentation.
The comment incorrectly stated that the trigger used IStorageProvider directly, which was resolved in PR #94.

## Type of change
- [x] Refactor / cleanup

## Checklist
- [x] `dotnet build` passes with **0 warnings**
- [x] `dotnet test` passes — no regressions